### PR TITLE
Extended RetroPlayerInput to provide multiple player support

### DIFF
--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -488,7 +488,7 @@ bool CApplication::OnEvent(XBMC_Event& newEvent)
       {
         CRetroPlayer* rp = dynamic_cast<CRetroPlayer*>(g_application.m_pPlayer);
         if (rp)
-          rp->GetInput().ProcessKeyUp(CKeyboardStat::TranslateKey(newEvent.key.keysym));
+          rp->GetInput().ProcessKeyUp(CKeyboardStat::TranslateKey(newEvent.key.keysym),0);
       }
       g_Keyboard.ProcessKeyUp();
       break;
@@ -2468,7 +2468,7 @@ bool CApplication::OnKey(const CKey& key)
       // Notify RetroPlayer's input system of the pressed key
       CRetroPlayer* rp = dynamic_cast<CRetroPlayer*>(m_pPlayer);
       if (rp)
-        rp->GetInput().ProcessKeyDown(key);
+        rp->GetInput().ProcessKeyDown(key,0);
 
       // Fetch action from <FullscreenGame> tag instead of <FullscreenVideo>
       action = CButtonTranslator::GetInstance().GetAction(WINDOW_FULLSCREEN_GAME, key);

--- a/xbmc/cores/RetroPlayer/RetroPlayerInput.cpp
+++ b/xbmc/cores/RetroPlayer/RetroPlayerInput.cpp
@@ -85,7 +85,10 @@ CRetroPlayerInput::CRetroPlayerInput() : m_bActive(false), m_gamepad()
 void CRetroPlayerInput::Begin()
 {
   memset(m_joypadState, 0, sizeof(m_joypadState));
-  m_gamepad = Gamepad();
+  for(int i =0; i < GAMEPAD_MAX_CONTROLLERS; i++)
+  {
+    m_gamepad[i] = Gamepad();
+  }  
   m_bActive = true;
 }
 
@@ -101,27 +104,27 @@ int16_t CRetroPlayerInput::GetInput(unsigned port, unsigned device, unsigned ind
 
   CSingleLock lock(m_statesGuard);
 
-  if (port == 0)
+  if (port < GAMEPAD_MAX_CONTROLLERS)
   {
     device &= RETRO_DEVICE_MASK;
 
     switch (device)
     {
     case RETRO_DEVICE_JOYPAD:
-      if (id < sizeof(m_joypadState) / sizeof(m_joypadState[0]))
-        return m_joypadState[id];
+      if (id < sizeof(m_joypadState[0]) / sizeof(m_joypadState[0][0]))
+        return m_joypadState[port][id];
       else
-        CLog::Log(LOGDEBUG, "RetroPlayerInput: GetInput() called with invalid ID: %d", id);
+        CLog::Log(LOGDEBUG, "RetroPlayerInput!!: Controller=%i, GetInput() called with invalid ID: %d", port, id);
       break;
     default: // Only RETRO_DEVICE_JOYPAD is supported currently
-      CLog::Log(LOGDEBUG, "RetroPlayerInput: GetInput() called with invalid device: %d", device);
+      CLog::Log(LOGDEBUG, "RetroPlayerInput!!: Controller=%i, GetInput() called with invalid device: %d", port, device);
       break;
     }
   }
   return 0;
 }
 
-void CRetroPlayerInput::ProcessKeyDown(const CKey &key)
+void CRetroPlayerInput::ProcessKeyDown(const CKey &key, unsigned controller_id)
 {
   // TODO: Use ID of current window, in case it defines joypad keys outside of
   // <FullscreenGame>. Maybe, if current window ID finds no action, then fallback
@@ -131,18 +134,18 @@ void CRetroPlayerInput::ProcessKeyDown(const CKey &key)
   CSingleLock lock(m_statesGuard);
 
   int id = TranslateActionID(action.GetID());
-  if (0 <= id && id < (int)(sizeof(m_joypadState) / sizeof(m_joypadState[0])))
+  if (0 <= id && id < (int)(sizeof(m_joypadState[0]) / sizeof(m_joypadState[0][0])))
   {
-    CLog::Log(LOGDEBUG, "RetroPlayerInput: KeyDown, action=%s, ID=%d", action.GetName().c_str(), id);
-    m_joypadState[id] = 1;
+    CLog::Log(LOGDEBUG, "RetroPlayerInput!!: Controller=%i, KeyDown, action=%s, ID=%d", controller_id, action.GetName().c_str(), id);
+    m_joypadState[controller_id][id] = 1;
   }
   else
   {
-    CLog::Log(LOGDEBUG, "RetroPlayerInput: Invalid KeyDown, action=%s, ID=%d", action.GetName().c_str(), action.GetID());
+    CLog::Log(LOGDEBUG, "RetroPlayerInput: Controller=%i, Invalid KeyDown, action=%s, ID=%d", controller_id, action.GetName().c_str(), action.GetID());
   }
 }
 
-void CRetroPlayerInput::ProcessKeyUp(const CKey &key)
+void CRetroPlayerInput::ProcessKeyUp(const CKey &key, unsigned controller_id)
 {
   // TODO: Use ID of current window, in case it defines joypad keys outside of
   // <FullscreenGame>. Maybe, if current window ID finds no action, then fallback
@@ -152,27 +155,30 @@ void CRetroPlayerInput::ProcessKeyUp(const CKey &key)
   CSingleLock lock(m_statesGuard);
 
   int id = TranslateActionID(action.GetID());
-  if (0 <= id && id < (int)(sizeof(m_joypadState) / sizeof(m_joypadState[0])))
+  if (0 <= id && id < (int)(sizeof(m_joypadState[0]) / sizeof(m_joypadState[0][0])))
   {
-    CLog::Log(LOGDEBUG, "RetroPlayerInput: KeyUp, action=%s, ID=%d", action.GetName().c_str(), id);
-    m_joypadState[id] = 0;
+    CLog::Log(LOGDEBUG, "RetroPlayerInput!!: Controller=%i, KeyUp, action=%s, ID=%d", controller_id, action.GetName().c_str(), id);
+    m_joypadState[controller_id][id] = 0;
   }
   else
   {
-    CLog::Log(LOGDEBUG, "RetroPlayerInput: Invalid KeyUp, action=%s, ID=%d", action.GetName().c_str(), action.GetID());
+    CLog::Log(LOGDEBUG, "RetroPlayerInput: Controller=%i, Invalid KeyUp, action=%s, ID=%d", controller_id, action.GetName().c_str(), action.GetID());
   }
 }
 
 void CRetroPlayerInput::ProcessGamepad(const Gamepad &gamepad)
 {
+  if (gamepad.id >= GAMEPAD_MAX_CONTROLLERS)
+    return;
+
   int window = !g_windowManager.HasModalDialog() ? g_windowManager.GetActiveWindow() : g_windowManager.GetTopMostModalDialogID();
 
   CSingleLock lock(m_statesGuard);
 
-  for (unsigned int b = 0; b < gamepad.buttonCount && b < m_gamepad.buttonCount; b++)
+  for (unsigned int b = 0; b < gamepad.buttonCount && b < m_gamepad[gamepad.id].buttonCount; b++)
   {
     // We only care if a change in state is detected
-    if (gamepad.buttons[b] == m_gamepad.buttons[b])
+    if (gamepad.buttons[b] == m_gamepad[gamepad.id].buttons[b])
       continue;
 
     // We only process button presses in WINDOW_FULLSCREEN_VIDEO. We check for
@@ -184,7 +190,7 @@ void CRetroPlayerInput::ProcessGamepad(const Gamepad &gamepad)
       continue;
 
     // Record the new state
-    m_gamepad.buttons[b] = gamepad.buttons[b];
+    m_gamepad[gamepad.id].buttons[b] = gamepad.buttons[b];
 
     int        actionID;
     CStdString actionName;
@@ -195,32 +201,32 @@ void CRetroPlayerInput::ProcessGamepad(const Gamepad &gamepad)
       continue;
 
     int id = TranslateActionID(actionID);
-    if (0 <= id && id < (int)(sizeof(m_joypadState) / sizeof(m_joypadState[0])))
+    if (0 <= id && id < (int)(sizeof(m_joypadState[0]) / sizeof(m_joypadState[0][0])))
     {
       // Record the new joypad state
-      m_joypadState[id] = gamepad.buttons[b];
-      CLog::Log(LOGDEBUG, "RetroPlayerInput: Gamepad %s button %s, action=%s, ID=%d", gamepad.name.c_str(),
+      m_joypadState[gamepad.id][id] = gamepad.buttons[b];
+      CLog::Log(LOGDEBUG, "RetroPlayerInput: Controller=%i, Gamepad %s button %s, action=%s, ID=%d", gamepad.id, gamepad.name.c_str(),
         gamepad.buttons[b] ? "press" : "unpress", actionName.c_str(), actionID);
     }
     else
     {
-      CLog::Log(LOGDEBUG, "RetroPlayerInput: Gamepad %s invalid button %s, action=%s, ID=%d", gamepad.name.c_str(),
+      CLog::Log(LOGDEBUG, "RetroPlayerInput: Controller=%i, Gamepad %s invalid button %s, action=%s, ID=%d", gamepad.id, gamepad.name.c_str(),
         gamepad.buttons[b] ? "press" : "unpress", actionName.c_str(), actionID);
     }
   }
 
-  for (unsigned int h = 0; h < gamepad.hatCount && h < m_gamepad.hatCount; h++)
+  for (unsigned int h = 0; h < gamepad.hatCount; h++)
   {
     // We only care if a change in state is detected
-    if (gamepad.hats[h] == m_gamepad.hats[h])
+    if (gamepad.hats[h] == m_gamepad[gamepad.id].hats[h])
       continue;
-    CLog::Log(LOGDEBUG, "RetroPlayerInput: Gamepad %s, new hat %d direction is %s",
-      gamepad.name.c_str(), h, gamepad.hats[h].GetDirection());
+    CLog::Log(LOGDEBUG, "RetroPlayerInput: Controller=%i, Gamepad %s, new hat %d direction is %s",
+      gamepad.id, gamepad.name.c_str(), h, gamepad.hats[h].GetDirection());
 
     // Using ordinal directions instead of cardinal directions lets us use a for loop efficiently
     for (unsigned int i = 0; i < 4; i++)
     {
-      if (gamepad.hats[h][i] == m_gamepad.hats[h][i])
+      if (gamepad.hats[h][i] == m_gamepad[gamepad.id].hats[h][i])
         continue;
 
       // Don't record presses outside of fullscreen video (unpresses are ok)
@@ -228,7 +234,7 @@ void CRetroPlayerInput::ProcessGamepad(const Gamepad &gamepad)
         continue;
 
       // Record the new state
-      m_gamepad.hats[h][i] = gamepad.hats[h][i];
+      m_gamepad[gamepad.id].hats[h][i] = gamepad.hats[h][i];
 
       // Compose button ID (SDL_HAT_UP is (1 << 0), SDL_HAT_RIGHT is (1 << 1), etc.)
       int        buttonID = (1 << i) << 16 | (h + 1); // Hat ID is h + 1
@@ -242,16 +248,16 @@ void CRetroPlayerInput::ProcessGamepad(const Gamepad &gamepad)
       static const char *dir[] = {"UP", "RIGHT", "DOWN", "LEFT"};
 
       int id = TranslateActionID(actionID);
-      if (0 <= id && id < (int)(sizeof(m_joypadState) / sizeof(m_joypadState[0])))
+      if (0 <= id && id < (int)(sizeof(m_joypadState[0]) / sizeof(m_joypadState[0][0])))
       {
         // Record the new joypad state
-        m_joypadState[id] = gamepad.hats[h][i];
-        CLog::Log(LOGDEBUG, "RetroPlayerInput: Hat %s %s, action=%s, ID=%d", dir[i],
+        m_joypadState[gamepad.id][id] = gamepad.hats[h][i];
+        CLog::Log(LOGDEBUG, "RetroPlayerInput: Controller=%i, Hat %s %s, action=%s, ID=%d", gamepad.id, dir[i],
           gamepad.hats[h][i] ? "press" : "unpress", actionName.c_str(), actionID);
       }
       else
       {
-        CLog::Log(LOGDEBUG, "RetroPlayerInput: Invalid hat %s %s, action=%s, ID=%d", dir[i],
+        CLog::Log(LOGDEBUG, "RetroPlayerInput: Controller=%i, Invalid hat %s %s, action=%s, ID=%d", gamepad.id, dir[i],
           gamepad.hats[h][i] ? "press" : "unpress", actionName.c_str(), actionID);
       }
     }

--- a/xbmc/cores/RetroPlayer/RetroPlayerInput.h
+++ b/xbmc/cores/RetroPlayer/RetroPlayerInput.h
@@ -31,6 +31,7 @@
 #define GAMEPAD_BUTTON_COUNT 128 // WINJoystick
 #define GAMEPAD_HAT_COUNT    4   // WINJoystick
 #define GAMEPAD_AXIS_COUNT   64  // SDLJoystick
+#define GAMEPAD_MAX_CONTROLLERS 4
 
 class CRetroPlayerInput
 {
@@ -91,14 +92,14 @@ public:
    * Marks a key as pressed. This intercepts keys sent to CApplication::OnKey()
    * before they are translated into actions.
    */
-  void ProcessKeyDown(const CKey &key);
+  void ProcessKeyDown(const CKey &key, unsigned controller_id);
 
   /**
    * Marks a key as released. Because key releases aren't processed by
    * CApplication and aren't translated into actions, these are intercepted
    * at the raw event stage in CApplication::OnEvent().
    */
-  void ProcessKeyUp(const CKey &key);
+  void ProcessKeyUp(const CKey &key, unsigned controller_id);
 
   /**
    * Monitor gamepads for input changes. This is called by g_Joystick.Update()
@@ -119,8 +120,8 @@ private:
   bool m_bActive; // Unused currently
 
   // RETRO_DEVICE_ID_JOYPAD_R3 is the last key in libretro.h
-  int16_t m_joypadState[ACTION_JOYPAD_CONTROL_END - ACTION_GAME_CONTROL_START + 1];
-  Gamepad m_gamepad;
+  int16_t m_joypadState[GAMEPAD_MAX_CONTROLLERS][ACTION_JOYPAD_CONTROL_END - ACTION_GAME_CONTROL_START + 1];
+  Gamepad m_gamepad[GAMEPAD_MAX_CONTROLLERS];
 
   CCriticalSection m_statesGuard;
 };


### PR DESCRIPTION
Added the ability to monitor up to 4 controllers (and extendable via
define)

Tested with up to 4 controllers, and inputs are all reconignzed.  (Only
tested with 4 XBOX controllers on a single wireless adaptor)
