### PR TITLE
[gameclient] Fix vfs file length check

### DIFF
--- a/xbmc/games/GameFileLoader.cpp
+++ b/xbmc/games/GameFileLoader.cpp
@@ -156,7 +156,7 @@ bool CGameFileLoader::GetGameInfo(LIBRETRO::retro_game_info &info) const
     length = vfsFile.GetLength();
 
     // Check for file size overflow (libretro accepts files <= size_t max)
-    if (length <= 0 || (long long)length >= (long long)std::numeric_limits<size_t>::max())
+    if (length <= 0 || (uint64_t)length > (uint64_t)std::numeric_limits<size_t>::max())
     {
       CLog::Log(LOGERROR, "GameClient: Invalid file size: %"PRId64" bytes", length);
       return false;


### PR DESCRIPTION
Type size_t is unsigned. Therefore the value std::numeric_limits<size_t>::max()
casted to a signed type (long long) might be interpreted as -1 (depending on
the system). This causes the length check to fail incorrectly.

The patch fixes an issue that games fail to be loaded from vfs on 64 bit Linux
with the message: 'ERROR: GameClient: Invalid file size XY bytes'

Nice work btw! I hope I got the correct dev branch. If not feel free to cherry-pick wherever this is needed.
