### PR TITLE
Made RETRO_ENFIRONMENT_GET_VARIABLE call only return default value

### DIFF
--- a/xbmc/games/libretro/LibretroEnvironment.cpp
+++ b/xbmc/games/libretro/LibretroEnvironment.cpp
@@ -350,11 +350,6 @@ bool CLibretroEnvironment::EnvironmentCallback(unsigned int cmd, void *data)
       {
         // m_varMap provides both a static layer for returning persistent strings,
         // and a way of detecting stale data for RETRO_ENVIRONMENT_GET_VARIABLE_UPDATE
-        if (false && m_activeClient)
-          m_varMap[var->key] = m_activeClient->GetSetting(var->key);
-        else
-          m_varMap[var->key] = "";
-
         if (!m_varMap[var->key].empty())
         {
           var->value = m_varMap[var->key].c_str();


### PR DESCRIPTION
This fixes pcsx playback on retroplayer (woooohoo I can play final fantasy in xbmc). This isn't really a fix by any means, just a way to show what was needed to make it work :)
