### PR TITLE
Input

### DIFF
--- a/xbmc/input/IJoystick.h
+++ b/xbmc/input/IJoystick.h
@@ -25,6 +25,7 @@
 #include <vector>
 #include <boost/shared_ptr.hpp>
 
+extern metrics m;
 /**
  * Interface IJoystick
  *
@@ -47,8 +48,19 @@ public:
   virtual ~IJoystick() { }
 
   virtual void Update() = 0;
+  
+  void UpdateState() { m_oldstate -= m_state; };
+  
+  void ResetState() {
+    m_state.ResetState();
+    m_oldstate.ResetState();
+  }
 
-  virtual const JOYSTICK::Joystick &GetState() const = 0;
+protected:
+  JOYSTICK::JoystickState m_state;
+  JOYSTICK::JoystickState m_oldstate;
 };
 
 typedef std::vector<boost::shared_ptr<IJoystick> > JoystickArray;
+
+extern metrics m;

--- a/xbmc/input/IJoystick.h
+++ b/xbmc/input/IJoystick.h
@@ -25,7 +25,6 @@
 #include <vector>
 #include <boost/shared_ptr.hpp>
 
-extern metrics m;
 /**
  * Interface IJoystick
  *
@@ -62,5 +61,3 @@ protected:
 };
 
 typedef std::vector<boost::shared_ptr<IJoystick> > JoystickArray;
-
-extern metrics m;

--- a/xbmc/input/Joystick.cpp
+++ b/xbmc/input/Joystick.cpp
@@ -20,10 +20,47 @@
 
 #include "Joystick.h"
 #include "settings/AdvancedSettings.h"
+#include "Application.h"
+#include "ButtonTranslator.h"
+#include "guilib/Key.h"
+#include "MouseStat.h"
+#include "utils/log.h"
+#include "settings/AdvancedSettings.h"
 
 #include <string.h>
 
+#define ACTION_FIRST_DELAY      500 // ms
+#define ACTION_REPEAT_DELAY     100 // ms
+#define AXIS_DIGITAL_DEADZONE   0.5f // Axis must be pushed past this for digital action repeats
+
+#ifndef ABS
+#define ABS(X) ((X) >= 0 ? (X) : (-(X)))
+#endif
+
 using namespace JOYSTICK;
+
+void ActionTracker::Reset()
+{
+  actionID = 0;
+  name.clear();
+  timeout.SetInfinite();
+}
+
+void ActionTracker::Track(const CAction &action)
+{
+  if (actionID != action.GetID())
+  {
+    // A new button was pressed, send the action and start tracking it
+    actionID = action.GetID();
+    name = action.GetName();
+    timeout.Set(ACTION_FIRST_DELAY);
+  }
+  else if (timeout.IsTimePast())
+  {
+    // Same button was pressed, send the action if the repeat delay has elapsed
+    timeout.Set(ACTION_REPEAT_DELAY);
+  }
+}
 
 void Hat::Center()
 {
@@ -64,7 +101,7 @@ const char *Hat::GetDirection() const
   }
 }
 
-void Joystick::ResetState(unsigned int buttonCount /* = GAMEPAD_BUTTON_COUNT */,
+void JoystickState::ResetState(unsigned int buttonCount /* = GAMEPAD_BUTTON_COUNT */,
                           unsigned int hatCount /* = GAMEPAD_HAT_COUNT */,
                           unsigned int axisCount /* = GAMEPAD_AXIS_COUNT */)
 {
@@ -77,7 +114,7 @@ void Joystick::ResetState(unsigned int buttonCount /* = GAMEPAD_BUTTON_COUNT */,
   axes.resize(axisCount);
 }
 
-void Joystick::SetAxis(unsigned int axis, long value, long maxAxisAmount)
+void JoystickState::SetAxis(unsigned int axis, long value, long maxAxisAmount)
 {
   if (axis >= axes.size())
     return;
@@ -94,4 +131,212 @@ void Joystick::SetAxis(unsigned int axis, long value, long maxAxisAmount)
     axes[axis] = (float)(value + deadzoneRange) / (float)(maxAxisAmount - deadzoneRange);
   else
     axes[axis] = 0.0f;
+}
+
+
+/* Modify the current state and create the actions. */
+JoystickState& JoystickState::operator-=(const JoystickState& rhs) {
+        ProcessButtonPresses(rhs);
+        ProcessHatPresses(rhs);
+        ProcessAxisMotion(rhs);
+        
+        // If tracking an action and the time has elapsed, execute the action now
+  if (m_actionTracker.actionID && m_actionTracker.timeout.IsTimePast())
+  {
+    CAction action(m_actionTracker.actionID, 1.0f, 0.0f, m_actionTracker.name);
+    g_application.ExecuteInputAction(action);
+    m_actionTracker.Track(action); // Update the timer
+  }
+
+  // Reset the wakeup check, so that the check will be performed for the next button press also
+  ResetWakeup();
+
+        return *this;
+}
+
+// Subtract this instance's value with the other, and return the new instance 
+// with the result
+const JoystickState JoystickState::operator-(const JoystickState &other) const {
+        return JoystickState(*this) -= other;
+}
+
+void JoystickState::ProcessButtonPresses(const JoystickState& newState)
+{
+  for (unsigned int i = 0; i < newState.buttons.size(); i++)
+  {
+    if (buttons[i] == newState.buttons[i])
+      continue;
+    buttons[i] = newState.buttons[i];
+
+    CLog::Log(LOGDEBUG, "Joystick %d button %d %s", id, i + 1, newState.buttons[i] ? "pressed" : "unpressed");
+
+    // Check to see if an action is registered for the button first
+    int        actionID;
+    CStdString actionName;
+    bool       fullrange;
+    // Button ID is i + 1
+    if (!CButtonTranslator::GetInstance().TranslateJoystickString(g_application.GetActiveWindowID(),
+                name.c_str(), i + 1, JACTIVE_BUTTON, actionID, actionName, fullrange))
+    {
+      CLog::Log(LOGDEBUG, "-> Joystick %d button %d no registered action", id, i + 1);
+      continue;
+    }
+    g_Mouse.SetActive(false);
+
+    // Ignore all button presses during this ProcessStateChanges() if we woke
+    // up the screensaver (but always send joypad unpresses)
+    if (!Wakeup() && newState.buttons[i])
+    {
+      CAction action(actionID, 1.0f, 0.0f, actionName);
+      g_application.ExecuteInputAction(action);
+      // Track the button press for deferred repeated execution
+      m_actionTracker.Track(action);
+    }
+    else if (!newState.buttons[i])
+    {
+      m_actionTracker.Reset(); // If a button was released, reset the tracker
+    }
+  }
+}
+
+void JoystickState::ProcessHatPresses(const JoystickState& newState)
+{
+  for (unsigned int i = 0; i < newState.hats.size(); i++)
+  {
+    Hat &oldHat = hats[i];
+    const Hat &newHat = newState.hats[i];
+    if (oldHat == newHat)
+      continue;
+
+    CLog::Log(LOGDEBUG, "Joystick %d hat %d new direction: %s", id, i + 1, newHat.GetDirection());
+
+    // Up, right, down, left
+    for (unsigned int j = 0; j < 4; j++)
+    {
+      if (oldHat[j] == newHat[j])
+        continue;
+      oldHat[j] = newHat[j];
+
+      int        actionID;
+      CStdString actionName;
+      bool       fullrange;
+      // Up is (1 << 0), right (1 << 1), down (1 << 2), left (1 << 3). Hat ID is i + 1
+      int buttonID = (1 << j) << 16 | (i + 1);
+      if (!buttonID || !CButtonTranslator::GetInstance().TranslateJoystickString(g_application.GetActiveWindowID(),
+        newState.name.c_str(), buttonID, JACTIVE_HAT, actionID, actionName, fullrange))
+      {
+        static const char *dir[] = {"UP", "RIGHT", "DOWN", "LEFT"};
+        CLog::Log(LOGDEBUG, "-> Joystick %d hat %d direction %s no registered action", id, i + 1, dir[j]);
+        continue;
+      }
+      g_Mouse.SetActive(false);
+
+      // Ignore all button presses during this ProcessStateChanges() if we woke
+      // up the screensaver (but always send joypad unpresses)
+      if (!Wakeup() && newHat[j])
+      {
+        CAction action(actionID, 1.0f, 0.0f, actionName);
+        g_application.ExecuteInputAction(action);
+        // Track the hat press for deferred repeated execution
+        m_actionTracker.Track(action);
+      }
+      else if (!newHat[j])
+      {
+        // If a hat was released, reset the tracker
+        m_actionTracker.Reset();
+      }
+    }
+  }
+}
+
+void JoystickState::ProcessAxisMotion(const JoystickState& newState)
+{
+  for (unsigned int i = 0; i < newState.axes.size(); i++)
+  {
+    // Absolute magnitude
+    float absAxis = ABS(newState.axes[i]);
+
+    // Only send one "centered" message
+    if (absAxis < 0.01f)
+    {
+      if (ABS(axes[i]) < 0.01f)
+      {
+        // The values might not have been exactly equal, so make them
+        axes[i] = newState.axes[i];
+        continue;
+      }
+      CLog::Log(LOGDEBUG, "Joystick %d axis %d centered", id, i + 1);
+    }
+    // Note: don't overwrite oldState until we know whether the action is analog or digital
+
+    int        actionID;
+    CStdString actionName;
+    bool       fullrange;
+    // Axis ID is i + 1, and negative if newState.axes[i] < 0
+    if (!CButtonTranslator::GetInstance().TranslateJoystickString(g_application.GetActiveWindowID(),
+      newState.name.c_str(), newState.axes[i] >= 0.0f ? (i + 1) : -(int)(i + 1), JACTIVE_AXIS, actionID,
+      actionName, fullrange))
+    {
+      continue;
+    }
+    g_Mouse.SetActive(false);
+
+    // Use newState.axes[i] as the second about so subscribers can recover the original value
+    CAction action(actionID, fullrange ? (newState.axes[i] + 1.0f) / 2.0f : absAxis, newState.axes[i], actionName);
+
+    // For digital event, we treat action repeats like buttons and hats
+    if (!CButtonTranslator::IsAnalog(actionID))
+    {
+      // NOW we overwrite old action and continue if no change in digital states
+      bool bContinue = !((ABS(axes[i]) >= AXIS_DIGITAL_DEADZONE) ^ (absAxis >= AXIS_DIGITAL_DEADZONE));
+      axes[i] = newState.axes[i];
+      if (bContinue)
+        continue;
+
+      if (absAxis >= 0.01f) // Because we already sent a "centered" message
+        CLog::Log(LOGDEBUG, "Joystick %d axis %d %s", id, i + 1,
+          absAxis >= AXIS_DIGITAL_DEADZONE ? "activated" : "deactivated (but not centered)");
+
+      if (!Wakeup() && absAxis >= AXIS_DIGITAL_DEADZONE)
+      {
+        g_application.ExecuteInputAction(action);
+        m_actionTracker.Track(action);
+      }
+      else if (absAxis < AXIS_DIGITAL_DEADZONE)
+      {
+        m_actionTracker.Reset();
+      }
+    }
+    else // CButtonTranslator::IsAnalog(actionID)
+    {
+      // We don't log about analog actions because they are sent every frame
+      axes[i] = newState.axes[i];
+
+      if (Wakeup())
+        continue;
+
+      if (newState.axes[i] != 0.0f)
+        g_application.ExecuteInputAction(action);
+
+      // The presence of analog actions disables others from being tracked
+      m_actionTracker.Reset();
+    }
+  }
+}
+
+bool JoystickState::Wakeup()
+{
+  static bool bWokenUp = false;
+
+  // Refresh bWokenUp after every call to ResetWakeup() (which sets m_bWakeupChecked to false)
+  if (!m_bWakeupChecked)
+  {
+    m_bWakeupChecked = true;
+
+    // Reset the timers and check to see if we have woken the application
+    g_application.ResetSystemIdleTimer();
+    g_application.ResetScreenSaver();
+    bWokenUp = g_application.WakeUpScreenSaverAndDPMS();
+  }
+  return bWokenUp;
 }

--- a/xbmc/input/Joystick.h
+++ b/xbmc/input/Joystick.h
@@ -102,9 +102,9 @@ struct Hat
 class JoystickState
 {
 public:
-  JoystickState() : id(0), m_bWakeupChecked((false) { ResetState(); }
-                  InputState& operator-=(const InputState& rhs);
-                const InputState operator-(const InputState &other) const;
+  JoystickState() : id(0), m_bWakeupChecked(false) { ResetState(); }
+                  JoystickState& operator-=(const JoystickState& rhs);
+                const JoystickState operator-(const JoystickState &other) const;
   void ResetState(unsigned int buttonCount = GAMEPAD_BUTTON_COUNT,
                   unsigned int hatCount = GAMEPAD_HAT_COUNT,
                   unsigned int axisCount = GAMEPAD_AXIS_COUNT);
@@ -127,9 +127,9 @@ private:
                 * @param newState - the updated joystick state
                 * @param joyID - the ID of the joystick being processed
                 */
-                void ProcessButtonPresses(const InputState& rhs);
-                void ProcessHatPresses(const InputState& rhs);
-                void ProcessAxisMotion(const InputState& rhs);
+                void ProcessButtonPresses(const JoystickState& rhs);
+                void ProcessHatPresses(const JoystickState& rhs);
+                void ProcessAxisMotion(const JoystickState& rhs);
 
                 // Returns true if this wakes up from the screensaver
                 bool Wakeup();

--- a/xbmc/input/JoystickManager.cpp
+++ b/xbmc/input/JoystickManager.cpp
@@ -22,13 +22,8 @@
 #if defined(HAS_JOYSTICK)
 
 #include "JoystickManager.h"
-#include "Application.h"
-#include "ButtonTranslator.h"
-#include "guilib/Key.h"
-#include "MouseStat.h"
 #include "peripherals/devices/PeripheralImon.h"
 #include "settings/Setting.h"
-#include "utils/log.h"
 #include "utils/StdString.h"
 
 // Include joystick APIs
@@ -43,43 +38,9 @@
 #include "input/linux/LinuxJoystickSDL.h"
 #endif
 
-#ifndef ARRAY_LENGTH
-#define ARRAY_LENGTH(x) (sizeof((x)) / sizeof((x)[0]))
-#endif
-#ifndef ABS
-#define ABS(X) ((X) >= 0 ? (X) : (-(X)))
-#endif
-
-#define ACTION_FIRST_DELAY      500 // ms
-#define ACTION_REPEAT_DELAY     100 // ms
-#define AXIS_DIGITAL_DEADZONE   0.5f // Axis must be pushed past this for digital action repeats
-
 using namespace JOYSTICK;
 using namespace PERIPHERALS;
 using namespace std;
-
-void ActionTracker::Reset()
-{
-  actionID = 0;
-  name.clear();
-  timeout.SetInfinite();
-}
-
-void ActionTracker::Track(const CAction &action)
-{
-  if (actionID != action.GetID())
-  {
-    // A new button was pressed, send the action and start tracking it
-    actionID = action.GetID();
-    name = action.GetName();
-    timeout.Set(ACTION_FIRST_DELAY);
-  }
-  else if (timeout.IsTimePast())
-  {
-    // Same button was pressed, send the action if the repeat delay has elapsed
-    timeout.Set(ACTION_REPEAT_DELAY);
-  }
-}
 
 CJoystickManager &CJoystickManager::Get()
 {
@@ -105,11 +66,11 @@ void CJoystickManager::Initialize()
 #endif
 
   // Truncate array
-  while (m_joysticks.size() > ARRAY_LENGTH(m_states))
+  while (m_joysticks.size() > GAMEPAD_MAX_CONTROLLERS)
     m_joysticks.pop_back();
 
-  for (unsigned int i = 0; i < ARRAY_LENGTH(m_states); i++)
-    m_states[i].ResetState();
+  for (unsigned int i = 0; i < GAMEPAD_MAX_CONTROLLERS; i++)
+    m_joysticks[i]->ResetState();
 }
 
 void CJoystickManager::DeInitialize()
@@ -126,10 +87,9 @@ void CJoystickManager::DeInitialize()
   CLinuxJoystickSDL::DeInitialize(m_joysticks);
 #endif
 
-  for (unsigned int i = 0; i < ARRAY_LENGTH(m_states); i++)
-    m_states[i].ResetState();
+  for (unsigned int i = 0; i < GAMEPAD_MAX_CONTROLLERS; i++)
+    m_joysticks[i]->ResetState();
 
-   m_actionTracker.Reset(); 
 }
 
 void CJoystickManager::Update()
@@ -137,213 +97,13 @@ void CJoystickManager::Update()
   if (!IsEnabled())
     return;
 
-  for (JoystickArray::iterator it = m_joysticks.begin(); it != m_joysticks.end(); it++)
+  for (JoystickArray::iterator it = m_joysticks.begin(); it != m_joysticks.end(); it++) {
     (*it)->Update();
-
-  ProcessStateChanges();
-}
-
-void CJoystickManager::ProcessStateChanges()
-{
-  for (unsigned int joyID = 0; joyID < m_joysticks.size(); joyID++)
-  {
-    ProcessButtonPresses(m_states[joyID], m_joysticks[joyID]->GetState(), joyID);
-    ProcessHatPresses(m_states[joyID], m_joysticks[joyID]->GetState(), joyID);
-    ProcessAxisMotion(m_states[joyID], m_joysticks[joyID]->GetState(), joyID);
+    (*it)->UpdateState();
   }
 
-  // If tracking an action and the time has elapsed, execute the action now
-  if (m_actionTracker.actionID && m_actionTracker.timeout.IsTimePast())
-  {
-    CAction action(m_actionTracker.actionID, 1.0f, 0.0f, m_actionTracker.name);
-    g_application.ExecuteInputAction(action);
-    m_actionTracker.Track(action); // Update the timer
-  }
-
-  // Reset the wakeup check, so that the check will be performed for the next button press also
-  ResetWakeup();
 }
 
-void CJoystickManager::ProcessButtonPresses(Joystick &oldState, const Joystick &newState, unsigned int joyID)
-{
-  for (unsigned int i = 0; i < newState.buttons.size(); i++)
-  {
-    if (oldState.buttons[i] == newState.buttons[i])
-      continue;
-    oldState.buttons[i] = newState.buttons[i];
-
-    CLog::Log(LOGDEBUG, "Joystick %d button %d %s", joyID, i + 1, newState.buttons[i] ? "pressed" : "unpressed");
-
-    // Check to see if an action is registered for the button first
-    int        actionID;
-    CStdString actionName;
-    bool       fullrange;
-    // Button ID is i + 1
-    if (!CButtonTranslator::GetInstance().TranslateJoystickString(g_application.GetActiveWindowID(),
-      newState.name.c_str(), i + 1, JACTIVE_BUTTON, actionID, actionName, fullrange))
-    {
-      CLog::Log(LOGDEBUG, "-> Joystick %d button %d no registered action", joyID, i + 1);
-      continue;
-    }
-    g_Mouse.SetActive(false);
-
-    // Ignore all button presses during this ProcessStateChanges() if we woke
-    // up the screensaver (but always send joypad unpresses)
-    if (!Wakeup() && newState.buttons[i])
-    {
-      CAction action(actionID, 1.0f, 0.0f, actionName);
-      g_application.ExecuteInputAction(action);
-      // Track the button press for deferred repeated execution
-      m_actionTracker.Track(action);
-    }
-    else if (!newState.buttons[i])
-    {
-      m_actionTracker.Reset(); // If a button was released, reset the tracker
-    }
-  }
-}
-
-void CJoystickManager::ProcessHatPresses(Joystick &oldState, const Joystick &newState, unsigned int joyID)
-{
-  for (unsigned int i = 0; i < newState.hats.size(); i++)
-  {
-    Hat &oldHat = oldState.hats[i];
-    const Hat &newHat = newState.hats[i];
-    if (oldHat == newHat)
-      continue;
-
-    CLog::Log(LOGDEBUG, "Joystick %d hat %d new direction: %s", joyID, i + 1, newHat.GetDirection());
-
-    // Up, right, down, left
-    for (unsigned int j = 0; j < 4; j++)
-    {
-      if (oldHat[j] == newHat[j])
-        continue;
-      oldHat[j] = newHat[j];
-
-      int        actionID;
-      CStdString actionName;
-      bool       fullrange;
-      // Up is (1 << 0), right (1 << 1), down (1 << 2), left (1 << 3). Hat ID is i + 1
-      int buttonID = (1 << j) << 16 | (i + 1);
-      if (!buttonID || !CButtonTranslator::GetInstance().TranslateJoystickString(g_application.GetActiveWindowID(),
-        newState.name.c_str(), buttonID, JACTIVE_HAT, actionID, actionName, fullrange))
-      {
-        static const char *dir[] = {"UP", "RIGHT", "DOWN", "LEFT"};
-        CLog::Log(LOGDEBUG, "-> Joystick %d hat %d direction %s no registered action", joyID, i + 1, dir[j]);
-        continue;
-      }
-      g_Mouse.SetActive(false);
-
-      // Ignore all button presses during this ProcessStateChanges() if we woke
-      // up the screensaver (but always send joypad unpresses)
-      if (!Wakeup() && newHat[j])
-      {
-        CAction action(actionID, 1.0f, 0.0f, actionName);
-        g_application.ExecuteInputAction(action);
-        // Track the hat press for deferred repeated execution
-        m_actionTracker.Track(action);
-      }
-      else if (!newHat[j])
-      {
-        // If a hat was released, reset the tracker
-        m_actionTracker.Reset();
-      }
-    }
-  }
-}
-
-void CJoystickManager::ProcessAxisMotion(Joystick &oldState, const Joystick &newState, unsigned int joyID)
-{
-  for (unsigned int i = 0; i < newState.axes.size(); i++)
-  {
-    // Absolute magnitude
-    float absAxis = ABS(newState.axes[i]);
-
-    // Only send one "centered" message
-    if (absAxis < 0.01f)
-    {
-      if (ABS(oldState.axes[i]) < 0.01f)
-      {
-        // The values might not have been exactly equal, so make them
-        oldState.axes[i] = newState.axes[i];
-        continue;
-      }
-      CLog::Log(LOGDEBUG, "Joystick %d axis %d centered", joyID, i + 1);
-    }
-    // Note: don't overwrite oldState until we know whether the action is analog or digital
-
-    int        actionID;
-    CStdString actionName;
-    bool       fullrange;
-    // Axis ID is i + 1, and negative if newState.axes[i] < 0
-    if (!CButtonTranslator::GetInstance().TranslateJoystickString(g_application.GetActiveWindowID(),
-      newState.name.c_str(), newState.axes[i] >= 0.0f ? (i + 1) : -(int)(i + 1), JACTIVE_AXIS, actionID,
-      actionName, fullrange))
-    {
-      continue;
-    }
-    g_Mouse.SetActive(false);
-
-    // Use newState.axes[i] as the second about so subscribers can recover the original value
-    CAction action(actionID, fullrange ? (newState.axes[i] + 1.0f) / 2.0f : absAxis, newState.axes[i], actionName);
-
-    // For digital event, we treat action repeats like buttons and hats
-    if (!CButtonTranslator::IsAnalog(actionID))
-    {
-      // NOW we overwrite old action and continue if no change in digital states
-      bool bContinue = !((ABS(oldState.axes[i]) >= AXIS_DIGITAL_DEADZONE) ^ (absAxis >= AXIS_DIGITAL_DEADZONE));
-      oldState.axes[i] = newState.axes[i];
-      if (bContinue)
-        continue;
-
-      if (absAxis >= 0.01f) // Because we already sent a "centered" message
-        CLog::Log(LOGDEBUG, "Joystick %d axis %d %s", joyID, i + 1,
-          absAxis >= AXIS_DIGITAL_DEADZONE ? "activated" : "deactivated (but not centered)");
-
-      if (!Wakeup() && absAxis >= AXIS_DIGITAL_DEADZONE)
-      {
-        g_application.ExecuteInputAction(action);
-        m_actionTracker.Track(action);
-      }
-      else if (absAxis < AXIS_DIGITAL_DEADZONE)
-      {
-        m_actionTracker.Reset();
-      }
-    }
-    else // CButtonTranslator::IsAnalog(actionID)
-    {
-      // We don't log about analog actions because they are sent every frame
-      oldState.axes[i] = newState.axes[i];
-
-      if (Wakeup())
-        continue;
-
-      if (newState.axes[i] != 0.0f)
-        g_application.ExecuteInputAction(action);
-
-      // The presence of analog actions disables others from being tracked
-      m_actionTracker.Reset();
-    }
-  }
-}
-
-bool CJoystickManager::Wakeup()
-{
-  static bool bWokenUp = false;
-
-  // Refresh bWokenUp after every call to ResetWakeup() (which sets m_bWakeupChecked to false)
-  if (!m_bWakeupChecked)
-  {
-    m_bWakeupChecked = true;
-
-    // Reset the timers and check to see if we have woken the application
-    g_application.ResetSystemIdleTimer();
-    g_application.ResetScreenSaver();
-    bWokenUp = g_application.WakeUpScreenSaverAndDPMS();
-  }
-  return bWokenUp;
-}
 
 void CJoystickManager::SetEnabled(bool enabled /* = true */)
 {

--- a/xbmc/input/JoystickManager.cpp
+++ b/xbmc/input/JoystickManager.cpp
@@ -56,7 +56,7 @@ void CJoystickManager::Initialize()
   // Initialize joystick APIs
 #if defined(TARGET_WINDOWS)
   CJoystickXInput::Initialize(m_joysticks);
-  CJoystickDX::Initialize(m_joysticks);
+  CJoystickDX::Initialize();
 #endif
 
 #if defined(HAS_LINUX_JOYSTICK)
@@ -69,8 +69,8 @@ void CJoystickManager::Initialize()
   while (m_joysticks.size() > GAMEPAD_MAX_CONTROLLERS)
     m_joysticks.pop_back();
 
-  for (unsigned int i = 0; i < GAMEPAD_MAX_CONTROLLERS; i++)
-    m_joysticks[i]->ResetState();
+  for (JoystickArray::iterator it = m_joysticks.begin(); it != m_joysticks.end(); it++)
+  (*it)->ResetState();
 }
 
 void CJoystickManager::DeInitialize()
@@ -87,8 +87,8 @@ void CJoystickManager::DeInitialize()
   CLinuxJoystickSDL::DeInitialize(m_joysticks);
 #endif
 
-  for (unsigned int i = 0; i < GAMEPAD_MAX_CONTROLLERS; i++)
-    m_joysticks[i]->ResetState();
+  for (JoystickArray::iterator it = m_joysticks.begin(); it != m_joysticks.end(); it++)
+    (*it)->ResetState();
 
 }
 

--- a/xbmc/input/JoystickManager.h
+++ b/xbmc/input/JoystickManager.h
@@ -22,28 +22,11 @@
 
 #include "IJoystick.h"
 #include "settings/ISettingCallback.h"
-#include "threads/SystemClock.h"
 
 #include <string>
 
-class CAction;
-
 namespace JOYSTICK
 {
-
-/**
- * Track key presses for deferred action repeats.
- */
-struct ActionTracker
-{
-  ActionTracker() { Reset(); }
-  void Reset();
-  void Track(const CAction &action);
-
-  int                  actionID; // Action ID, or 0 if not tracking any action
-  std::string          name; // Action name
-  XbmcThreads::EndTime timeout; // Timeout until action is repeated
-};
 
 /**
  * Class to manage all connected joysticks.
@@ -51,7 +34,7 @@ struct ActionTracker
 class CJoystickManager : public ISettingCallback
 {
 private:
-  CJoystickManager() : m_bEnabled(false), m_bWakeupChecked(false) { }
+  CJoystickManager() : m_bEnabled(false) { }
   virtual ~CJoystickManager() { DeInitialize(); }
 
 public:
@@ -62,7 +45,6 @@ public:
   void Update();
   unsigned int Count() const { return m_joysticks.size(); }
   void Reinitialize() { Initialize(); }
-  void Reset() { m_actionTracker.Reset(); }
 
   // Inherited from ISettingCallback
   virtual void OnSettingChanged(const CSetting *setting);
@@ -71,28 +53,9 @@ private:
   void Initialize();
   void DeInitialize();
 
-  /**
-   * After updating, look for changes in state.
-   * @param oldState - previous joystick state, set to newState as a post-condition
-   * @param newState - the updated joystick state
-   * @param joyID - the ID of the joystick being processed
-   */
-  void ProcessStateChanges();
-  void ProcessButtonPresses(Joystick &oldState, const Joystick &newState, unsigned int joyID);
-  void ProcessHatPresses(Joystick &oldState, const Joystick &newState, unsigned int joyID);
-  void ProcessAxisMotion(Joystick &oldState, const Joystick &newState, unsigned int joyID);
-
-  // Returns true if this wakes up from the screensaver
-  bool Wakeup();
-  // Allows Wakeup() to perform another wakeup check
-  void ResetWakeup() { m_bWakeupChecked = false; }
-
   JoystickArray m_joysticks;
-  Joystick      m_states[GAMEPAD_MAX_CONTROLLERS];
   bool          m_bEnabled;
-  bool          m_bWakeupChecked; // true if WakeupCheck() has been called
 
-  ActionTracker m_actionTracker;
 };
 
 } // namespace INPUT

--- a/xbmc/input/JoystickManager.h
+++ b/xbmc/input/JoystickManager.h
@@ -45,6 +45,9 @@ public:
   void Update();
   unsigned int Count() const { return m_joysticks.size(); }
   void Reinitialize() { Initialize(); }
+  void Reset() { 
+    //Action tracker removed, what does this do now? 
+  }
 
   // Inherited from ISettingCallback
   virtual void OnSettingChanged(const CSetting *setting);

--- a/xbmc/input/linux/LinuxJoystick.cpp
+++ b/xbmc/input/linux/LinuxJoystick.cpp
@@ -85,7 +85,7 @@ static const char *button_names[KEY_MAX - BTN_MISC + 1] =
 };
 
 CLinuxJoystick::CLinuxJoystick(int fd, unsigned int id, const char *name, const std::string &filename,
-    unsigned char buttons, unsigned char axes) : m_state(), m_fd(fd), m_filename(filename)
+    unsigned char buttons, unsigned char axes) : m_fd(fd), m_filename(filename)
 {
   m_state.id          = id;
   m_state.name        = name;

--- a/xbmc/input/linux/LinuxJoystick.h
+++ b/xbmc/input/linux/LinuxJoystick.h
@@ -37,7 +37,6 @@ public:
 
   virtual ~CLinuxJoystick();
   virtual void Update();
-  virtual const JOYSTICK::Joystick &GetState() const { return m_state; }
 
 private:
   CLinuxJoystick(int fd, unsigned int id, const char *name, const std::string &filename, unsigned char buttons, unsigned char axes);
@@ -46,7 +45,6 @@ private:
   static int GetAxisMap(int fd, uint8_t *axisMap);
   static int DetermineIoctl(int fd, int *ioctls, uint16_t *buttonMap, int &ioctl_used);
 
-  JOYSTICK::Joystick m_state;
   int                m_fd;
   std::string        m_filename; // for debugging purposes
 };

--- a/xbmc/input/linux/LinuxJoystickSDL.cpp
+++ b/xbmc/input/linux/LinuxJoystickSDL.cpp
@@ -32,7 +32,7 @@
 
 using namespace JOYSTICK;
 
-CLinuxJoystickSDL::CLinuxJoystickSDL(std::string name, SDL_Joystick *pJoystick, unsigned int id) : m_pJoystick(pJoystick), m_state()
+CLinuxJoystickSDL::CLinuxJoystickSDL(std::string name, SDL_Joystick *pJoystick, unsigned int id) : m_pJoystick(pJoystick)
 {
   m_state.id          = id;
   m_state.name        = name;

--- a/xbmc/input/linux/LinuxJoystickSDL.h
+++ b/xbmc/input/linux/LinuxJoystickSDL.h
@@ -35,11 +35,9 @@ public:
 
   virtual ~CLinuxJoystickSDL() { }
   virtual void Update();
-  virtual const JOYSTICK::Joystick &GetState() const { return m_state; }
 
 private:
   CLinuxJoystickSDL(std::string name, SDL_Joystick *pJoystick, unsigned int id);
   
   SDL_Joystick *m_pJoystick;
-  JOYSTICK::Joystick m_state;
 };


### PR DESCRIPTION
The Joystick Manager no longer handles the nitty gritty work of handling the Joystick states, and now only iterates through the Joysticks to call their update methods. The Joystick struct is now a JoystickState class with an overloaded operator-, which is used to compare states and fire off an event, and is protected class member of the Joystick interface. Removed any cases of the state being passed out of the class.

The action tracker was also moved out of the Joystick Manager, and exists in every JoystickState. I wasn't too sure on what to do with it, but perhaps it can be clarified if this needs to be fixed in my implementation.