### PR TITLE
fix paths to game emulator addons

### DIFF
--- a/xbmc/cores/RetroPlayer/RetroPlayerDialogs.cpp
+++ b/xbmc/cores/RetroPlayer/RetroPlayerDialogs.cpp
@@ -120,7 +120,7 @@ bool CRetroPlayerDialogs::GameLauchDialog(const CFileItem &file, GameClientPtr &
     CGameManager::Get().SetAutoLaunch(fileCopy);
     CLog::Log(LOGDEBUG, "RetroPlayer: User chose to go to the add-on manager");
     std::vector<std::string> params;
-    params.push_back("addons://all/kodi.gameclient");
+    params.push_back("addons://user/kodi.gameclient");
     g_windowManager.ActivateWindow(WINDOW_ADDON_BROWSER, params);
   }
   else
@@ -344,7 +344,7 @@ bool CRetroPlayerDialogs::ChooseGameClientDialog(const std::vector<std::string> 
 
     CLog::Log(LOGDEBUG, "RetroPlayer: User chose to go to the add-on manager");
     std::vector<std::string> params;
-    params.push_back("addons://all/kodi.gameclient");
+    params.push_back("addons://user/kodi.gameclient");
     g_windowManager.ActivateWindow(WINDOW_ADDON_BROWSER, params);
     return false;
   }

--- a/xbmc/games/GameSettings.cpp
+++ b/xbmc/games/GameSettings.cpp
@@ -43,7 +43,7 @@ void CGameSettings::OnSettingAction(const CSetting* setting)
   if (settingId == "gamesgeneral.manageaddons")
   {
     std::vector<std::string> params;
-    params.push_back("addons://all/kodi.gameclient");
+    params.push_back("addons://user/kodi.gameclient");
     g_windowManager.ActivateWindow(WINDOW_ADDON_BROWSER, params);
   }
   else if (settingId == "gamesinput.controllerconfig")


### PR DESCRIPTION
This fixes the paths to the game emulator addons node for the "Manage emulators..." buttons in settings and in the game launch dialog.