### PR TITLE
[win32] binary addons: improvement for MinGW and platform specific dependency handling

### DIFF
--- a/project/cmake/addons/depends/windows/cmake/mingw/CMakeLists.txt
+++ b/project/cmake/addons/depends/windows/cmake/mingw/CMakeLists.txt
@@ -13,6 +13,9 @@ set(MINGW_PATH "${CMAKE_INSTALL_PREFIX}/mingw")
 # configure the MinGW toolchain file
 configure_file(${PROJECT_SOURCE_DIR}/Toolchain_mingw32.cmake.in ${CMAKE_INSTALL_PREFIX}/Toolchain_mingw32.cmake @ONLY)
 
+# configure mingw-config.cmake
+configure_file(${PROJECT_SOURCE_DIR}/mingw-config.cmake.in ${CMAKE_INSTALL_PREFIX}/mingw-config.cmake)
+
 # configure the MinGW wrapper batch scripts
 generate_mingw32_wrapper("mingw32-make")
 generate_mingw32_wrapper("mingw32-gcc")

--- a/project/cmake/addons/depends/windows/cmake/mingw/mingw-config.cmake.in
+++ b/project/cmake/addons/depends/windows/cmake/mingw/mingw-config.cmake.in
@@ -1,0 +1,3 @@
+set(MINGW_INCLUDE_DIRS @MINGW_PATH@/include)
+set(MINGW_MAKE @MINGW_PATH@/bin/mingw32-make.bat)
+set(MINGW_FOUND 1)

--- a/project/cmake/scripts/common/handle-depends.cmake
+++ b/project/cmake/scripts/common/handle-depends.cmake
@@ -36,6 +36,7 @@ function(add_addon_depends addon searchpath)
             file MATCHES noinstall.txt OR
             file MATCHES flags.txt OR
             file MATCHES deps.txt OR
+            file MATCHES "[a-z]+-deps[.]txt" OR
             file MATCHES platforms.txt))
       message(STATUS "Processing ${file}")
       file(STRINGS ${file} def)
@@ -148,8 +149,11 @@ function(add_addon_depends addon searchpath)
           set(INSTALL_COMMAND INSTALL_COMMAND "")
         endif()
 
-        # check if there's a deps.txt containing dependencies on other libraries
-        if(EXISTS ${dir}/deps.txt)
+        # check if there's a platform-specific or generic deps.txt containing dependencies on other libraries
+        if(EXISTS ${dir}/${CORE_SYSTEM_NAME}-deps.txt)
+          file(STRINGS ${dir}/${CORE_SYSTEM_NAME}-deps.txt deps)
+          message(STATUS "${id} depends: ${deps}")
+        elseif(EXISTS ${dir}/deps.txt)
           file(STRINGS ${dir}/deps.txt deps)
           message(STATUS "${id} depends: ${deps}")
         else()


### PR DESCRIPTION
These two commits are necessary for the buildsystem restructuring of libretro game addons.
The first commit can be merged into one of the commits of the MinGW PR (will do that in my PR to mainline).