### PR TITLE
[GSoC 2015] Add VideoFrameH264 to CRetroplayerVideo

### DIFF
--- a/addons/kodi.game/addon.xml
+++ b/addons/kodi.game/addon.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<addon id="kodi.game" version="1.0.12" provider-name="Team-Kodi">
-	<backwards-compatibility abi="1.0.12"/>
+<addon id="kodi.game" version="1.0.13" provider-name="Team-Kodi">
+	<backwards-compatibility abi="1.0.13"/>
 	<requires>
 		<import addon="xbmc.core" version="0.1.0"/>
 	</requires>

--- a/addons/library.kodi.game/libKODI_game.h
+++ b/addons/library.kodi.game/libKODI_game.h
@@ -99,6 +99,7 @@ public:
       if (!GAME_REGISTER_SYMBOL(m_libKODI_game, GAME_unregister_me)) throw false;
       if (!GAME_REGISTER_SYMBOL(m_libKODI_game, GAME_close_game)) throw false;
       if (!GAME_REGISTER_SYMBOL(m_libKODI_game, GAME_video_frame)) throw false;
+      if (!GAME_REGISTER_SYMBOL(m_libKODI_game, GAME_video_frame_h264)) throw false;
       if (!GAME_REGISTER_SYMBOL(m_libKODI_game, GAME_audio_frames)) throw false;
       if (!GAME_REGISTER_SYMBOL(m_libKODI_game, GAME_hw_set_info)) throw false;
       if (!GAME_REGISTER_SYMBOL(m_libKODI_game, GAME_hw_get_current_framebuffer)) throw false;
@@ -125,6 +126,11 @@ public:
   void VideoFrame(const uint8_t* data, unsigned int size, unsigned int width, unsigned int height, GAME_RENDER_FORMAT format)
   {
     return GAME_video_frame(m_handle, m_callbacks, data, size, width, height, format);
+  }
+
+  bool VideoFrameH264(const uint8_t* data, unsigned int size, unsigned int width, unsigned int height)
+  {
+    return GAME_video_frame_h264(m_handle, m_callbacks, data, size, width, height);
   }
 
   void AudioFrames(const uint8_t* data, unsigned int size, unsigned int frames, GAME_AUDIO_FORMAT format)
@@ -167,6 +173,7 @@ protected:
   void (*GAME_unregister_me)(void* handle, CB_GameLib* cb);
   void (*GAME_close_game)(void* handle, CB_GameLib* cb);
   void (*GAME_video_frame)(void* handle, CB_GameLib* cb, const uint8_t*, unsigned int, unsigned int, unsigned int, GAME_RENDER_FORMAT);
+  bool (*GAME_video_frame_h264)(void* handle, CB_GameLib* cb, const uint8_t*, int, unsigned int, unsigned int);
   void (*GAME_audio_frames)(void* handle, CB_GameLib* cb, const uint8_t*, unsigned int, unsigned int, GAME_AUDIO_FORMAT);
   void (*GAME_hw_set_info)(void* handle, CB_GameLib* cb, const struct game_hw_info*);
   uintptr_t (*GAME_hw_get_current_framebuffer)(void* handle, CB_GameLib* cb);

--- a/lib/addons/library.kodi.game/libKODI_game.cpp
+++ b/lib/addons/library.kodi.game/libKODI_game.cpp
@@ -69,6 +69,13 @@ DLLEXPORT void GAME_video_frame(AddonCB* frontend, CB_GameLib* cb, const uint8_t
   return cb->VideoFrame(frontend->addonData, data, size, width, height, format);
 }
 
+DLLEXPORT bool GAME_video_frame_h264(AddonCB* frontend, CB_GameLib* cb, const uint8_t* data, unsigned int size, unsigned int width, unsigned int height)
+{
+  if (frontend == NULL || cb == NULL)
+    return false;
+  return cb->VideoFrameH264(frontend->addonData, data, size, width, height);
+}
+
 DLLEXPORT void GAME_audio_frames(AddonCB* frontend, CB_GameLib* cb, const uint8_t* data, unsigned int size, unsigned int frames, GAME_AUDIO_FORMAT format)
 {
   if (frontend == NULL || cb == NULL)

--- a/xbmc/addons/AddonCallbacksGame.cpp
+++ b/xbmc/addons/AddonCallbacksGame.cpp
@@ -38,6 +38,7 @@ CAddonCallbacksGame::CAddonCallbacksGame(CAddon* addon)
   /* write XBMC game specific add-on function addresses to callback table */
   m_callbacks->CloseGame                      = CloseGame;
   m_callbacks->VideoFrame                     = VideoFrame;
+  m_callbacks->VideoFrameH264                 = VideoFrameH264;
   m_callbacks->AudioFrames                    = AudioFrames;
   m_callbacks->HwSetInfo                      = HwSetInfo;
   m_callbacks->HwGetCurrentFramebuffer        = HwGetCurrentFramebuffer;
@@ -130,6 +131,15 @@ void CAddonCallbacksGame::VideoFrame(void* addonData, const uint8_t* data, unsig
     return;
 
   retroPlayer->VideoFrame(data, size, width, height, pixelFormat);
+}
+
+bool CAddonCallbacksGame::VideoFrameH264(void* addonData, const uint8_t* data, unsigned int size, unsigned int width, unsigned int height)
+{
+  CRetroPlayer* retroPlayer = GetRetroPlayer(addonData, __FUNCTION__);
+  if (!retroPlayer)
+    return false;
+
+  return retroPlayer->VideoFrameH264(data, size, width, height);
 }
 
 void CAddonCallbacksGame::AudioFrames(void* addonData, const uint8_t* data, unsigned int size, unsigned int frames, GAME_AUDIO_FORMAT format)

--- a/xbmc/addons/AddonCallbacksGame.h
+++ b/xbmc/addons/AddonCallbacksGame.h
@@ -46,6 +46,7 @@ public:
 
   static void CloseGame(void* addonData);
   static void VideoFrame(void* addonData, const uint8_t* data, unsigned int size, unsigned int width, unsigned int height, GAME_RENDER_FORMAT format);
+  static bool VideoFrameH264(void* addonData, const uint8_t* data, unsigned int size, unsigned int width, unsigned int height);
   static void AudioFrames(void* addonData, const uint8_t* data, unsigned int size, unsigned int frames, GAME_AUDIO_FORMAT format);
   static void HwSetInfo(void* addonData, const game_hw_info* hw_info);
   static uintptr_t HwGetCurrentFramebuffer(void* addonData);

--- a/xbmc/addons/include/kodi_game_callbacks.h
+++ b/xbmc/addons/include/kodi_game_callbacks.h
@@ -47,6 +47,16 @@ typedef struct CB_GameLib
   void (*VideoFrame)(void* addonData, const uint8_t* data, unsigned int size, unsigned int width, unsigned int height, GAME_RENDER_FORMAT format);
 
   /*!
+   * \brief Render a H264 frame
+   *
+   * \param data The frame's data
+   * \param size The size of the data
+   * \param width The width, in pixels
+   * \param height The height, in pixels
+   */
+  bool (*VideoFrameH264)(void* addonData, const uint8_t* data, unsigned int size, unsigned int width, unsigned int height);
+
+  /*!
    * \brief Render a chunk of audio data
    *
    * \param data The audio data

--- a/xbmc/addons/include/kodi_game_types.h
+++ b/xbmc/addons/include/kodi_game_types.h
@@ -21,10 +21,10 @@
 #define KODI_GAME_TYPES_H_
 
 /* current game API version */
-#define GAME_API_VERSION                "1.0.12"
+#define GAME_API_VERSION                "1.0.13"
 
 /* min. game API version */
-#define GAME_MIN_API_VERSION            "1.0.12"
+#define GAME_MIN_API_VERSION            "1.0.13"
 
 #include <stddef.h>
 #include <stdint.h>

--- a/xbmc/cores/RetroPlayer/RetroPlayer.h
+++ b/xbmc/cores/RetroPlayer/RetroPlayer.h
@@ -128,6 +128,7 @@ public:
 
   // Game API
   void VideoFrame(const uint8_t* data, unsigned int size, unsigned int width, unsigned int height, AVPixelFormat format) { m_video.VideoFrame(data, size, width, height, format); }
+  bool VideoFrameH264(const uint8_t* data, unsigned int size, unsigned int width, unsigned int height) { return m_video.VideoFrameH264(data, size, width, height); }
   void AudioFrames(const uint8_t* data, unsigned int size, unsigned int frames, AEDataFormat format) { m_audio.AudioFrames(data, size, frames, format); }
 
 protected:

--- a/xbmc/cores/RetroPlayer/RetroPlayerVideo.h
+++ b/xbmc/cores/RetroPlayer/RetroPlayerVideo.h
@@ -27,6 +27,9 @@
 
 struct DVDVideoPicture;
 struct SwsContext;
+struct AVCodec;
+struct AVCodecContext;
+struct AVFrame;
 
 class CRetroPlayerVideo : protected CThread
 {
@@ -39,13 +42,15 @@ public:
 
   bool VideoFrame(const uint8_t* data, unsigned int size, unsigned int width, unsigned int height, AVPixelFormat format);
 
+  bool VideoFrameH264(const uint8_t* data, unsigned int size, unsigned int width, unsigned int height);
+
 protected:
   virtual void Process(void);
 
 private:
   void Cleanup(void);
 
-  bool Configure(unsigned int width, unsigned int height, AVPixelFormat format);
+  bool Configure(unsigned int width, unsigned int height, AVPixelFormat format, bool setupH264=false);
 
   void ColorspaceConversion(const uint8_t* data, unsigned int size, unsigned int width, unsigned int height, DVDVideoPicture &output);
 
@@ -59,4 +64,7 @@ private:
   bool              m_bFrameReady;
   CCriticalSection  m_frameReadyMutex;
   CEvent            m_frameReadyEvent;
+  AVCodec*          m_codec;
+  AVCodecContext*   m_codec_context;
+  AVFrame*          m_frame;
 };


### PR DESCRIPTION
This set of patches adds support for decoding H264 frames through the Retroplayer by taking advantage of the ffmpeg backend of Kodi. This is done in two parts, by adding the functionality into `CRetroplayerVideo`, and the corresponding callbacks to the Game API.

Having this functionality would help with the work oan [game.moonlight](https://github.com/acmiyaguchi/game.moonlight).

As a note, this has only been tested on a 64 bit Linux machine, in particular Ubuntu-14.04. I haven't gotten around to building on osx yet. 
