### PR TITLE
Peripheral API: Allow mapping analog sticks to buttons

### DIFF
--- a/addons/kodi.peripheral/addon.xml
+++ b/addons/kodi.peripheral/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<addon id="kodi.peripheral" version="1.0.9" provider-name="Team-Kodi">
+<addon id="kodi.peripheral" version="1.0.10" provider-name="Team-Kodi">
 	<requires>
 		<import addon="xbmc.core" version="0.1.0"/>
 	</requires>

--- a/addons/kodi.peripheral/addon.xml
+++ b/addons/kodi.peripheral/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<addon id="kodi.peripheral" version="1.0.0" provider-name="Team-Kodi">
+<addon id="kodi.peripheral" version="1.0.9" provider-name="Team-Kodi">
 	<requires>
 		<import addon="xbmc.core" version="0.1.0"/>
 	</requires>

--- a/project/cmake/addons/addons/peripheral.joystick/peripheral.joystick.txt
+++ b/project/cmake/addons/addons/peripheral.joystick/peripheral.joystick.txt
@@ -1,1 +1,1 @@
-peripheral.joystick https://github.com/kodi-game/peripheral.joystick 04d3044
+peripheral.joystick https://github.com/kodi-game/peripheral.joystick acceb70

--- a/xbmc/addons/include/kodi_peripheral_dll.h
+++ b/xbmc/addons/include/kodi_peripheral_dll.h
@@ -125,16 +125,16 @@ extern "C"
   void FreeJoystickInfo(JOYSTICK_INFO* info);
 
   /*!
-   * @brief Get the features that allow translation from the joystick to the given device
+   * @brief Get the features that allow translating the joystick into the controller profile
    * @param joystick      The device's joystick properties; unknown values may be left at their default
-   * @param controller_id The controller profile being requested
+   * @param controller_id The controller profile being requested, e.g. game.controller.default
    * @param feature_count The number of features allocated for the features array
    * @param features      The array of allocated features
    * @return PERIPHERAL_NO_ERROR if successful; array must be freed using
    *         FreeButtonMap() in this case
    */
-  PERIPHERAL_ERROR GetButtonMap(const JOYSTICK_INFO* joystick, const char* controller_id,
-                                unsigned int* feature_count, JOYSTICK_FEATURE** features);
+  PERIPHERAL_ERROR GetFeatures(const JOYSTICK_INFO* joystick, const char* controller_id,
+                               unsigned int* feature_count, JOYSTICK_FEATURE** features);
 
   /*!
    * @brief Free the memory allocated in GetButtonMap()
@@ -144,17 +144,17 @@ extern "C"
    * @param feature_count  The number of features allocated for the features array
    * @param features       The array of allocated features
    */
-  void FreeButtonMap(unsigned int feature_count, JOYSTICK_FEATURE* features);
+  void FreeFeatures(unsigned int feature_count, JOYSTICK_FEATURE* features);
 
   /*!
-   * @brief Update joystick feature
+   * @brief Add or update joystick feature
    * @param joystick      The device's joystick properties; unknown values may be left at their default
-   * @param controller_id The controller profile being updated
-   * @param feature       The feature's new driver value
+   * @param controller_id The game controller profile being updated
+   * @param feature       The feature's new properties
    * @return PERIPHERAL_NO_ERROR if successful
    */
-  PERIPHERAL_ERROR MapJoystickFeature(const JOYSTICK_INFO* joystick, const char* controller_id,
-                                      JOYSTICK_FEATURE* feature);
+  PERIPHERAL_ERROR AddFeature(const JOYSTICK_INFO* joystick, const char* controller_id,
+                              JOYSTICK_FEATURE* feature);
 #endif
   ///}
 
@@ -176,9 +176,9 @@ extern "C"
 #ifdef PERIPHERAL_ADDON_JOYSTICKS
     pClient->GetJoystickInfo                = GetJoystickInfo;
     pClient->FreeJoystickInfo               = FreeJoystickInfo;
-    pClient->GetButtonMap                   = GetButtonMap;
-    pClient->FreeButtonMap                  = FreeButtonMap;
-    pClient->MapJoystickFeature             = MapJoystickFeature;
+    pClient->GetFeatures                    = GetFeatures;
+    pClient->FreeFeatures                   = FreeFeatures;
+    pClient->AddFeature                     = AddFeature;
 #endif
   }
 

--- a/xbmc/addons/include/kodi_peripheral_types.h
+++ b/xbmc/addons/include/kodi_peripheral_types.h
@@ -50,10 +50,10 @@
 #endif
 
 /* current Peripheral API version */
-#define PERIPHERAL_API_VERSION "1.0.9"
+#define PERIPHERAL_API_VERSION "1.0.10"
 
 /* min. Peripheral API version */
-#define PERIPHERAL_MIN_API_VERSION "1.0.9"
+#define PERIPHERAL_MIN_API_VERSION "1.0.10"
 
 /* indicates a joystick has no preference for port number */
 #define NO_PORT_REQUESTED     (-1)
@@ -175,15 +175,13 @@ extern "C"
     unsigned int    axis_count;         /*!< @brief number of axes reported by the driver */
   } ATTRIBUTE_PACKED JOYSTICK_INFO;
 
-  typedef enum JOYSTICK_DRIVER_TYPE
+  typedef enum JOYSTICK_DRIVER_PRIMITIVE_TYPE
   {
-    JOYSTICK_DRIVER_TYPE_UNKNOWN,
-    JOYSTICK_DRIVER_TYPE_BUTTON,
-    JOYSTICK_DRIVER_TYPE_HAT_DIRECTION,
-    JOYSTICK_DRIVER_TYPE_SEMIAXIS,
-    JOYSTICK_DRIVER_TYPE_ANALOG_STICK,
-    JOYSTICK_DRIVER_TYPE_ACCELEROMETER,
-  } JOYSTICK_DRIVER_TYPE;
+    JOYSTICK_DRIVER_PRIMITIVE_TYPE_UNKNOWN,
+    JOYSTICK_DRIVER_PRIMITIVE_TYPE_BUTTON,
+    JOYSTICK_DRIVER_PRIMITIVE_TYPE_HAT_DIRECTION,
+    JOYSTICK_DRIVER_PRIMITIVE_TYPE_SEMIAXIS,
+  } JOYSTICK_DRIVER_PRIMITIVE_TYPE;
 
   typedef struct JOYSTICK_DRIVER_BUTTON
   {
@@ -218,35 +216,54 @@ extern "C"
     JOYSTICK_DRIVER_SEMIAXIS_DIRECTION direction;
   } ATTRIBUTE_PACKED JOYSTICK_DRIVER_SEMIAXIS;
 
-  typedef struct JOYSTICK_DRIVER_ANALOG_STICK
+  typedef struct JOYSTICK_DRIVER_PRIMITIVE
   {
-    int  x_index;
-    bool x_inverted;
-    int  y_index;
-    bool y_inverted;
-  } ATTRIBUTE_PACKED JOYSTICK_DRIVER_ANALOG_STICK;
+    JOYSTICK_DRIVER_PRIMITIVE_TYPE    type;
+    union
+    {
+      struct JOYSTICK_DRIVER_BUTTON   button;
+      struct JOYSTICK_DRIVER_HAT      hat;
+      struct JOYSTICK_DRIVER_SEMIAXIS semiaxis;
+    };
+  } ATTRIBUTE_PACKED JOYSTICK_DRIVER_PRIMITIVE;
 
-  typedef struct JOYSTICK_DRIVER_ACCELEROMETER
+  typedef enum JOYSTICK_FEATURE_TYPE
   {
-    int  x_index;
-    bool x_inverted;
-    int  y_index;
-    bool y_inverted;
-    int  z_index;
-    bool z_inverted;
-  } ATTRIBUTE_PACKED JOYSTICK_DRIVER_ACCELEROMETER;
+    JOYSTICK_FEATURE_TYPE_UNKNOWN,
+    JOYSTICK_FEATURE_TYPE_PRIMITIVE,
+    JOYSTICK_FEATURE_TYPE_ANALOG_STICK,
+    JOYSTICK_FEATURE_TYPE_ACCELEROMETER,
+  } JOYSTICK_FEATURE_TYPE;
+
+  typedef struct JOYSTICK_FEATURE_PRIMITIVE
+  {
+    struct JOYSTICK_DRIVER_PRIMITIVE primitive;
+  } ATTRIBUTE_PACKED JOYSTICK_FEATURE_PRIMITIVE;
+
+  typedef struct JOYSTICK_FEATURE_ANALOG_STICK
+  {
+    struct JOYSTICK_DRIVER_PRIMITIVE up;
+    struct JOYSTICK_DRIVER_PRIMITIVE down;
+    struct JOYSTICK_DRIVER_PRIMITIVE right;
+    struct JOYSTICK_DRIVER_PRIMITIVE left;
+  } ATTRIBUTE_PACKED JOYSTICK_FEATURE_ANALOG_STICK;
+
+  typedef struct JOYSTICK_FEATURE_ACCELEROMETER
+  {
+    struct JOYSTICK_DRIVER_PRIMITIVE positive_x;
+    struct JOYSTICK_DRIVER_PRIMITIVE positive_y;
+    struct JOYSTICK_DRIVER_PRIMITIVE positive_z;
+  } ATTRIBUTE_PACKED JOYSTICK_FEATURE_ACCELEROMETER;
 
   typedef struct JOYSTICK_FEATURE
   {
-    char*                                  feature_name;
-    JOYSTICK_DRIVER_TYPE                   driver_type;
+    char*                                   name;
+    JOYSTICK_FEATURE_TYPE                   type;
     union
     {
-      struct JOYSTICK_DRIVER_BUTTON        driver_button;
-      struct JOYSTICK_DRIVER_HAT           driver_hat;
-      struct JOYSTICK_DRIVER_SEMIAXIS      driver_semiaxis;
-      struct JOYSTICK_DRIVER_ANALOG_STICK  driver_analog_stick;
-      struct JOYSTICK_DRIVER_ACCELEROMETER driver_accelerometer;
+      struct JOYSTICK_FEATURE_PRIMITIVE     primitive;
+      struct JOYSTICK_FEATURE_ANALOG_STICK  analog_stick;
+      struct JOYSTICK_FEATURE_ACCELEROMETER accelerometer;
     };
   } ATTRIBUTE_PACKED JOYSTICK_FEATURE;
   ///}

--- a/xbmc/addons/include/kodi_peripheral_types.h
+++ b/xbmc/addons/include/kodi_peripheral_types.h
@@ -50,10 +50,10 @@
 #endif
 
 /* current Peripheral API version */
-#define PERIPHERAL_API_VERSION "1.0.8"
+#define PERIPHERAL_API_VERSION "1.0.9"
 
 /* min. Peripheral API version */
-#define PERIPHERAL_MIN_API_VERSION "1.0.8"
+#define PERIPHERAL_MIN_API_VERSION "1.0.9"
 
 /* indicates a joystick has no preference for port number */
 #define NO_PORT_REQUESTED     (-1)
@@ -270,9 +270,9 @@ extern "C"
     ///{
     PERIPHERAL_ERROR (__cdecl* GetJoystickInfo)(unsigned int, JOYSTICK_INFO*);
     void             (__cdecl* FreeJoystickInfo)(JOYSTICK_INFO*);
-    PERIPHERAL_ERROR (__cdecl* GetButtonMap)(const JOYSTICK_INFO*, const char*, unsigned int*, JOYSTICK_FEATURE**);
-    void             (__cdecl* FreeButtonMap)(unsigned int, JOYSTICK_FEATURE*);
-    PERIPHERAL_ERROR (__cdecl* MapJoystickFeature)(const JOYSTICK_INFO*, const char*, JOYSTICK_FEATURE*);
+    PERIPHERAL_ERROR (__cdecl* GetFeatures)(const JOYSTICK_INFO*, const char*, unsigned int*, JOYSTICK_FEATURE**);
+    void             (__cdecl* FreeFeatures)(unsigned int, JOYSTICK_FEATURE*);
+    PERIPHERAL_ERROR (__cdecl* AddFeature)(const JOYSTICK_INFO*, const char*, JOYSTICK_FEATURE*);
     ///}
   } PeripheralAddon;
 

--- a/xbmc/games/windows/wizards/GUIControllerWizard.cpp
+++ b/xbmc/games/windows/wizards/GUIControllerWizard.cpp
@@ -260,28 +260,21 @@ bool CGUIControllerWizard::MapPrimitive(IJoystickButtonMap* buttonMap, const CJo
     {
       case STATE_PROMPT_BUTTON:
       {
-        bHandled = buttonMap->MapButton(features[m_featureIndex].Name(), primitive);
+        bHandled = buttonMap->AddPrimitiveFeature(features[m_featureIndex].Name(), primitive);
         break;
       }
       case STATE_PROMPT_ANALOG_STICK_UP:
       {
         if (primitive.Type() == DriverPrimitiveTypeSemiAxis)
         {
-          int  horizIndex = -1;
-          bool horizInverted = false;
-          int  vertIndex = -1;
-          bool vertInverted = false;
+          CJoystickDriverPrimitive up;
+          CJoystickDriverPrimitive down;
+          CJoystickDriverPrimitive right;
+          CJoystickDriverPrimitive left;
 
-          buttonMap->GetAnalogStick(features[m_featureIndex].Name(),
-                                    horizIndex, horizInverted,
-                                    vertIndex,  vertInverted);
+          buttonMap->GetAnalogStick(features[m_featureIndex].Name(), up, down, right, left);
 
-          vertIndex = primitive.Index();
-          vertInverted = (primitive.SemiAxisDir() == SemiAxisDirectionNegative);
-
-          bHandled = buttonMap->MapAnalogStick(features[m_featureIndex].Name(),
-                                               horizIndex, horizInverted,
-                                               vertIndex,  vertInverted);
+          bHandled = buttonMap->AddAnalogStick(features[m_featureIndex].Name(), primitive, down, right,  left);
 
           m_lastAnalogStickDir = primitive;
         }
@@ -289,29 +282,33 @@ bool CGUIControllerWizard::MapPrimitive(IJoystickButtonMap* buttonMap, const CJo
       }
       case STATE_PROMPT_ANALOG_STICK_DOWN:
       {
-        bHandled = true; // TODO
-        m_lastAnalogStickDir = primitive;
+        if (primitive.Type() == DriverPrimitiveTypeSemiAxis)
+        {
+          CJoystickDriverPrimitive up;
+          CJoystickDriverPrimitive down;
+          CJoystickDriverPrimitive right;
+          CJoystickDriverPrimitive left;
+
+          buttonMap->GetAnalogStick(features[m_featureIndex].Name(), up, down, right, left);
+
+          bHandled = buttonMap->AddAnalogStick(features[m_featureIndex].Name(), up, primitive, right,  left);
+
+          m_lastAnalogStickDir = primitive;
+        }
         break;
       }
       case STATE_PROMPT_ANALOG_STICK_RIGHT:
       {
         if (primitive.Type() == DriverPrimitiveTypeSemiAxis)
         {
-          int  horizIndex = -1;
-          bool horizInverted = false;
-          int  vertIndex = -1;
-          bool vertInverted = false;
+          CJoystickDriverPrimitive up;
+          CJoystickDriverPrimitive down;
+          CJoystickDriverPrimitive right;
+          CJoystickDriverPrimitive left;
 
-          buttonMap->GetAnalogStick(features[m_featureIndex].Name(),
-                                    horizIndex, horizInverted,
-                                    vertIndex,  vertInverted);
+          buttonMap->GetAnalogStick(features[m_featureIndex].Name(), up, down, right, left);
 
-          horizIndex = primitive.Index();
-          horizInverted = (primitive.SemiAxisDir() == SemiAxisDirectionNegative);
-
-          bHandled = buttonMap->MapAnalogStick(features[m_featureIndex].Name(),
-                                               horizIndex, horizInverted,
-                                               vertIndex,  vertInverted);
+          bHandled = buttonMap->AddAnalogStick(features[m_featureIndex].Name(), up, down, primitive,  left);
 
           m_lastAnalogStickDir = primitive;
         }
@@ -319,8 +316,19 @@ bool CGUIControllerWizard::MapPrimitive(IJoystickButtonMap* buttonMap, const CJo
       }
       case STATE_PROMPT_ANALOG_STICK_LEFT:
       {
-        bHandled = true; // TODO
-        m_lastAnalogStickDir = primitive;
+        if (primitive.Type() == DriverPrimitiveTypeSemiAxis)
+        {
+          CJoystickDriverPrimitive up;
+          CJoystickDriverPrimitive down;
+          CJoystickDriverPrimitive right;
+          CJoystickDriverPrimitive left;
+
+          buttonMap->GetAnalogStick(features[m_featureIndex].Name(), up, down, right, left);
+
+          bHandled = buttonMap->AddAnalogStick(features[m_featureIndex].Name(), up, down, right,  primitive);
+
+          m_lastAnalogStickDir = primitive;
+        }
         break;
       }
       default:

--- a/xbmc/input/joysticks/IJoystickButtonMap.h
+++ b/xbmc/input/joysticks/IJoystickButtonMap.h
@@ -57,7 +57,7 @@ public:
   /*!
    * \brief Get the feature associated with a driver primitive
    *
-   * \param button       The driver primitive (a button, hat direction or semi-axis)
+   * \param primitive    The driver primitive (a button, hat direction or semi-axis)
    * \param feature      The name of the resolved joystick feature, or
    *                         unmodified if GetFeature() returns false
    *
@@ -68,93 +68,87 @@ public:
   /*!
    * \brief Get the driver primitive associated with a digital or analog button
    *
-   * \param feature        The analog or digital button
-   * \param button         The resolved driver primitive
+   * \param feature        Must be an analog or digital button or this will return false
+   * \param primitive      The resolved driver primitive
    *
    * \return True if the index resolved to a driver primitive, false if the feature
    *         didn't resolve or isn't a digital or analog button
    */
-  virtual bool GetButton(const JoystickFeature& feature, CJoystickDriverPrimitive& button) = 0;
+  virtual bool GetPrimitiveFeature(const JoystickFeature& feature, CJoystickDriverPrimitive& primitive) = 0;
 
   /*!
-   * \brief Map a digital or analog button to a driver primitive
+   * \brief Add or update a digital or analog button
    *
-   * \param feature        The analog or digital button being mapped
+   * \param feature        Must be an analog or digital button or this will return false
    * \param primitive      The driver primitive
    *
-   * \return True if the button was updated, false otherwise
+   * \return True if the feature was updated, false otherwise
    */
-  virtual bool MapButton(const JoystickFeature& feature, const CJoystickDriverPrimitive& primitive) = 0;
+  virtual bool AddPrimitiveFeature(const JoystickFeature& feature, const CJoystickDriverPrimitive& primitive) = 0;
 
   /*!
-   * \brief Get the raw axis indices and polarity for the given analog stick
+   * \brief Get an analog stick from the button map
    *
-   * \param feature        The analog stick
-   * \param horizIndex     The index of the axis corresponding to the analog
-   *                           stick's horizontal motion, or -1 if unknown
-   * \param horizInverted  False if right is positive, true if right is negative
-   * \param vertIndex      The index of the axis corresponding to the analog
-   *                           stick's vertical motion, or -1 if unknown
-   * \param vertInverted   False if up is positive, true if up is negative
+   * \param feature  Must be an analog stick or this will return false
+   * \param up       The primitive mapped to the up direction (possibly unknown)
+   * \param down     The primitive mapped to the down direction (possibly unknown)
+   * \param right    The primitive mapped to the right direction (possibly unknown)
+   * \param left     The primitive mapped to the left direction (possibly unknown)
    *
-   * \return True if the feature resolved to an analog stick with at least 1 known axis
+   * It is not required that these primitives be axes. If a primitive is a
+   * semiaxis, its opposite should point to the same axis index but with
+   * opposite direction.
+   *
+   * \return True if the feature resolved to an analog stick with at least 1 known direction
    */
-  virtual bool GetAnalogStick(const JoystickFeature& feature, int& horizIndex, bool& horizInverted,
-                                                              int& vertIndex,  bool& vertInverted) = 0;
+  virtual bool GetAnalogStick(const JoystickFeature& feature, CJoystickDriverPrimitive& up,
+                                                              CJoystickDriverPrimitive& down,
+                                                              CJoystickDriverPrimitive& right,
+                                                              CJoystickDriverPrimitive& left) = 0;
 
   /*!
-   * \brief Map an analog stick to horizontal and vertical axes
+   * \brief Add or update an analog stick
    *
-   * \param feature        The analog stick
-   * \param horizIndex     The index of the axis corresponding to the analog
-   *                           stick's horizontal motion, or -1 if unknown
-   * \param horizInverted  False if right is positive, true if right is negative
-   * \param vertIndex      The index of the axis corresponding to the analog
-   *                           stick's vertical motion, or -1 if unknown
-   * \param vertInverted   False if up is positive, true if up is negative
+   * \param feature  Must be an analog stick or this will return false
+   * \param up       The driver primitive for the up direction
+   * \param down     The driver primitive for the down direction
+   * \param right    The driver primitive for the right direction
+   * \param left     The driver primitive for the left direction
    *
    * \return True if the analog stick was updated, false otherwise
    */
-  virtual bool MapAnalogStick(const JoystickFeature& feature, int horizIndex, bool horizInverted,
-                                                              int vertIndex,  bool vertInverted) = 0;
+  virtual bool AddAnalogStick(const JoystickFeature& feature, const CJoystickDriverPrimitive& up,
+                                                              const CJoystickDriverPrimitive& down,
+                                                              const CJoystickDriverPrimitive& right,
+                                                              const CJoystickDriverPrimitive& left) = 0;
 
   /*!
-   * \brief Get the raw axis indices and polarity for the given accelerometer
+   * \brief Get an accelerometer from the button map
    *
-   * \param feature       The accelerometer
-   * \param xIndex        The index of the axis corresponding to the accelerometer's
-   *                          X-axis, or -1 if unknown
-   * \param xInverted     False if positive X is positive, true if positive X is negative
-   * \param yIndex        The index of the axis corresponding to the accelerometer's
-   *                          Y-axis, or -1 if unknown
-   * \param yInverted     False if positive Y is positive, true if positive Y is negative
-   * \param zIndex        The index of the axis corresponding to the accelerometer's
-   *                          Z-axis, or -1 if unknown
-   * \param zInverted     False if positive X is positive, true if positive Z is negative
+   * \param feature       Must be an accelerometer or this will return false
+   * \param positiveX     The semiaxis mapped to the positive X direction (possibly unknown)
+   * \param positiveY     The semiaxis mapped to the positive Y direction (possibly unknown)
+   * \param positiveZ     The semiaxis mapped to the positive Z direction (possibly unknown)
    *
    * \return True if the feature resolved to an accelerometer with at least 1 known axis
    */
-  virtual bool GetAccelerometer(const JoystickFeature& feature, int& xIndex, bool& xInverted,
-                                                                int& yIndex, bool& yInverted,
-                                                                int& zIndex, bool& zInverted) = 0;
+  virtual bool GetAccelerometer(const JoystickFeature& feature, CJoystickDriverPrimitive& positiveX,
+                                                                CJoystickDriverPrimitive& positiveY,
+                                                                CJoystickDriverPrimitive& positiveZ) = 0;
 
   /*!
-   * \brief Map an accelerometer to x, y and z axes
+   * \brief Get or update an accelerometer
    *
-   * \param feature       The accelerometer
-   * \param xIndex        The index of the axis corresponding to the accelerometer's
-   *                          X-axis, or -1 if unknown
-   * \param xInverted     False if positive X is positive, true if positive X is negative
-   * \param yIndex        The index of the axis corresponding to the accelerometer's
-   *                          Y-axis, or -1 if unknown
-   * \param yInverted     False if positive Y is positive, true if positive Y is negative
-   * \param zIndex        The index of the axis corresponding to the accelerometer's
-   *                          Z-axis, or -1 if unknown
-   * \param zInverted     False if positive X is positive, true if positive Z is negative
+   * \param feature       Must be an accelerometer or this will return false
+   * \param positiveX     The semiaxis corresponding to the positive X direction
+   * \param positiveY     The semiaxis corresponding to the positive Y direction
+   * \param positiveZ     The semiaxis corresponding to the positive Z direction
+   *
+   * If the driver primitives are not mapped to a semiaxis, they will be ignored.
    *
    * \return True if the accelerometer was updated, false otherwise
    */
-  virtual bool MapAccelerometer(const JoystickFeature& feature, int xIndex, bool xInverted,
-                                                                int yIndex, bool yInverted,
-                                                                int zIndex, bool zInverted) = 0;
+  virtual bool AddAccelerometer(const JoystickFeature& feature, const CJoystickDriverPrimitive& positiveX,
+                                                                const CJoystickDriverPrimitive& positiveY,
+                                                                const CJoystickDriverPrimitive& positiveZ) = 0;
 };

--- a/xbmc/input/joysticks/generic/GenericJoystickInputHandling.cpp
+++ b/xbmc/input/joysticks/generic/GenericJoystickInputHandling.cpp
@@ -197,24 +197,43 @@ void CGenericJoystickInputHandling::ProcessAxisMotions(void)
   {
     const JoystickFeature& feature = *it;
 
-    int  xIndex;
-    bool xInverted;
-    int  yIndex;
-    bool yInverted;
-    int  zIndex;
-    bool zInverted;
+    CJoystickDriverPrimitive up;
+    CJoystickDriverPrimitive down;
+    CJoystickDriverPrimitive right;
+    CJoystickDriverPrimitive left;
 
-    if (m_buttonMap->GetAnalogStick(feature, xIndex, xInverted, yIndex,  yInverted))
+    CJoystickDriverPrimitive positiveX;
+    CJoystickDriverPrimitive positiveY;
+    CJoystickDriverPrimitive positiveZ;
+
+    if (m_buttonMap->GetAnalogStick(feature, up, down, right,  left))
     {
-      const float horizPos = GetAxisState(xIndex) * (xInverted ? -1.0f : 1.0f);
-      const float vertPos  = GetAxisState(yIndex)  * (yInverted  ? -1.0f : 1.0f);
+      float horizPos = 0.0f;
+      float vertPos = 0.0f;
+
+      if (right.Type() == DriverPrimitiveTypeSemiAxis)
+        horizPos = GetAxisState(right.Index()) * static_cast<int>(right.SemiAxisDir());
+
+      if (up.Type() == DriverPrimitiveTypeSemiAxis)
+        vertPos  = GetAxisState(up.Index())  * static_cast<int>(up.SemiAxisDir());
+
       m_handler->OnAnalogStickMotion(feature, horizPos, vertPos);
     }
-    else if (m_buttonMap->GetAccelerometer(feature, xIndex, xInverted, yIndex, yInverted, zIndex, zInverted))
+    else if (m_buttonMap->GetAccelerometer(feature, positiveX, positiveY, positiveZ))
     {
-      const float xPos = GetAxisState(xIndex) * (xInverted ? -1.0f : 1.0f);
-      const float yPos = GetAxisState(yIndex) * (yInverted ? -1.0f : 1.0f);
-      const float zPos = GetAxisState(zIndex) * (zInverted ? -1.0f : 1.0f);
+      float xPos = 0.0f;
+      float yPos = 0.0f;
+      float zPos = 0.0f;
+
+      if (positiveX.Type() == DriverPrimitiveTypeSemiAxis)
+        xPos = GetAxisState(positiveX.Index()) * static_cast<int>(positiveX.SemiAxisDir());
+
+      if (positiveY.Type() == DriverPrimitiveTypeSemiAxis)
+        yPos = GetAxisState(positiveY.Index()) * static_cast<int>(positiveY.SemiAxisDir());
+
+      if (positiveZ.Type() == DriverPrimitiveTypeSemiAxis)
+        zPos = GetAxisState(positiveZ.Index()) * static_cast<int>(positiveZ.SemiAxisDir());
+
       m_handler->OnAccelerometerMotion(feature, xPos, yPos, zPos);
     }
   }

--- a/xbmc/peripherals/addons/AddonJoystickButtonMap.cpp
+++ b/xbmc/peripherals/addons/AddonJoystickButtonMap.cpp
@@ -48,48 +48,46 @@ bool CAddonJoystickButtonMap::GetFeature(const CJoystickDriverPrimitive& primiti
   return m_buttonMapRO.GetFeature(primitive, feature);
 }
 
-bool CAddonJoystickButtonMap::GetButton(const JoystickFeature& feature, CJoystickDriverPrimitive& button)
+bool CAddonJoystickButtonMap::GetPrimitiveFeature(const JoystickFeature& feature, CJoystickDriverPrimitive& primitive)
 {
-  return m_buttonMapRO.GetButton(feature, button);
+  return m_buttonMapRO.GetPrimitiveFeature(feature, primitive);
 }
 
-bool CAddonJoystickButtonMap::MapButton(const JoystickFeature& feature, const CJoystickDriverPrimitive& primitive)
+bool CAddonJoystickButtonMap::AddPrimitiveFeature(const JoystickFeature& feature, const CJoystickDriverPrimitive& primitive)
 {
-  return m_buttonMapWO.MapButton(feature, primitive);
+  return m_buttonMapWO.AddPrimitiveFeature(feature, primitive);
 }
 
 bool CAddonJoystickButtonMap::GetAnalogStick(const JoystickFeature& feature,
-                                             int& horizIndex, bool& horizInverted,
-                                             int& vertIndex,  bool& vertInverted)
+                                             CJoystickDriverPrimitive& up,
+                                             CJoystickDriverPrimitive& down,
+                                             CJoystickDriverPrimitive& right,
+                                             CJoystickDriverPrimitive& left)
 {
-  return m_buttonMapRO.GetAnalogStick(feature, horizIndex, horizInverted,
-                                               vertIndex, vertInverted);
+  return m_buttonMapRO.GetAnalogStick(feature, up, down, right, left);
 }
 
-bool CAddonJoystickButtonMap::MapAnalogStick(const JoystickFeature& feature,
-                                             int horizIndex, bool horizInverted,
-                                             int vertIndex,  bool vertInverted)
+bool CAddonJoystickButtonMap::AddAnalogStick(const JoystickFeature& feature,
+                                             const CJoystickDriverPrimitive& up,
+                                             const CJoystickDriverPrimitive& down,
+                                             const CJoystickDriverPrimitive& right,
+                                             const CJoystickDriverPrimitive& left)
 {
-  return m_buttonMapWO.MapAnalogStick(feature, horizIndex, horizInverted,
-                                               vertIndex, vertInverted);
+  return m_buttonMapWO.AddAnalogStick(feature, up, down, right, left);
 }
 
 bool CAddonJoystickButtonMap::GetAccelerometer(const JoystickFeature& feature,
-                                               int& xIndex, bool& xInverted,
-                                               int& yIndex, bool& yInverted,
-                                               int& zIndex, bool& zInverted)
+                                               CJoystickDriverPrimitive& positiveX,
+                                               CJoystickDriverPrimitive& positiveY,
+                                               CJoystickDriverPrimitive& positiveZ)
 {
-  return m_buttonMapRO.GetAccelerometer(feature, xIndex, xInverted,
-                                                 yIndex, yInverted,
-                                                 zIndex, zInverted);
+  return m_buttonMapRO.GetAccelerometer(feature, positiveX, positiveY, positiveZ);
 }
 
-bool CAddonJoystickButtonMap::MapAccelerometer(const JoystickFeature& feature,
-                                               int xIndex, bool xInverted,
-                                               int yIndex, bool yInverted,
-                                               int zIndex, bool zInverted)
+bool CAddonJoystickButtonMap::AddAccelerometer(const JoystickFeature& feature,
+                                               const CJoystickDriverPrimitive& positiveX,
+                                               const CJoystickDriverPrimitive& positiveY,
+                                               const CJoystickDriverPrimitive& positiveZ)
 {
-  return m_buttonMapWO.MapAccelerometer(feature, xIndex, xInverted,
-                                                 yIndex, yInverted,
-                                                 zIndex, zInverted);
+  return m_buttonMapWO.AddAccelerometer(feature, positiveX, positiveY, positiveZ);
 }

--- a/xbmc/peripherals/addons/AddonJoystickButtonMap.h
+++ b/xbmc/peripherals/addons/AddonJoystickButtonMap.h
@@ -37,18 +37,22 @@ namespace PERIPHERALS
     virtual std::string ControllerID(void) const { return m_buttonMapRO.ControllerID(); }
     virtual bool Load(void);
     virtual bool GetFeature(const CJoystickDriverPrimitive& primitive, JoystickFeature& feature);
-    virtual bool GetButton(const JoystickFeature& feature, CJoystickDriverPrimitive& button);
-    virtual bool MapButton(const JoystickFeature& feature, const CJoystickDriverPrimitive& primitive);
-    virtual bool GetAnalogStick(const JoystickFeature& feature, int& horizIndex, bool& horizInverted,
-                                                                int& vertIndex,  bool& vertInverted);
-    virtual bool MapAnalogStick(const JoystickFeature& feature, int horizIndex, bool horizInverted,
-                                                                int vertIndex,  bool vertInverted);
-    virtual bool GetAccelerometer(const JoystickFeature& feature, int& xIndex, bool& xInverted,
-                                                                  int& yIndex, bool& yInverted,
-                                                                  int& zIndex, bool& zInverted);
-    virtual bool MapAccelerometer(const JoystickFeature& feature, int xIndex, bool xInverted,
-                                                                  int yIndex, bool yInverted,
-                                                                  int zIndex, bool zInverted);
+    virtual bool GetPrimitiveFeature(const JoystickFeature& feature, CJoystickDriverPrimitive& primitive);
+    virtual bool AddPrimitiveFeature(const JoystickFeature& feature, const CJoystickDriverPrimitive& primitive);
+    virtual bool GetAnalogStick(const JoystickFeature& feature, CJoystickDriverPrimitive& up,
+                                                                CJoystickDriverPrimitive& down,
+                                                                CJoystickDriverPrimitive& right,
+                                                                CJoystickDriverPrimitive& left);
+    virtual bool AddAnalogStick(const JoystickFeature& feature, const CJoystickDriverPrimitive& up,
+                                                                const CJoystickDriverPrimitive& down,
+                                                                const CJoystickDriverPrimitive& right,
+                                                                const CJoystickDriverPrimitive& left);
+    virtual bool GetAccelerometer(const JoystickFeature& feature, CJoystickDriverPrimitive& positiveX,
+                                                                  CJoystickDriverPrimitive& positiveY,
+                                                                  CJoystickDriverPrimitive& positiveZ);
+    virtual bool AddAccelerometer(const JoystickFeature& feature, const CJoystickDriverPrimitive& positiveX,
+                                                                  const CJoystickDriverPrimitive& positiveY,
+                                                                  const CJoystickDriverPrimitive& positiveZ);
 
   private:
     PeripheralAddonPtr        m_addon;

--- a/xbmc/peripherals/addons/AddonJoystickButtonMapRO.cpp
+++ b/xbmc/peripherals/addons/AddonJoystickButtonMapRO.cpp
@@ -36,7 +36,7 @@ bool CAddonJoystickButtonMapRO::Load(void)
   m_features.clear();
   m_driverMap.clear();
 
-  if (m_addon && m_addon->GetButtonMap(m_device, m_strControllerId, m_features))
+  if (m_addon && m_addon->GetFeatures(m_device, m_strControllerId, m_features))
   {
     CLog::Log(LOGDEBUG, "Loaded button map with %lu features for controller %s",
               m_features.size(), m_strControllerId.c_str());

--- a/xbmc/peripherals/addons/AddonJoystickButtonMapRO.h
+++ b/xbmc/peripherals/addons/AddonJoystickButtonMapRO.h
@@ -25,6 +25,7 @@
 #include "peripherals/addons/PeripheralAddon.h"
 
 #include <map>
+#include <string>
 
 namespace PERIPHERALS
 {
@@ -36,21 +37,24 @@ namespace PERIPHERALS
     std::string ControllerID(void) const { return m_strControllerId; }
     bool Load(void);
     bool GetFeature(const CJoystickDriverPrimitive& primitive, JoystickFeature& feature);
-    bool GetButton(const JoystickFeature& feature, CJoystickDriverPrimitive& button);
-    bool GetAnalogStick(const JoystickFeature& feature, int& horizIndex, bool& horizInverted,
-                                                        int& vertIndex,  bool& vertInverted);
-    bool GetAccelerometer(const JoystickFeature& feature, int& xIndex, bool& xInverted,
-                                                          int& yIndex, bool& yInverted,
-                                                          int& zIndex, bool& zInverted);
+    bool GetPrimitiveFeature(const JoystickFeature& feature, CJoystickDriverPrimitive& primitive);
+    bool GetAnalogStick(const JoystickFeature& feature, CJoystickDriverPrimitive& up,
+                                                        CJoystickDriverPrimitive& down,
+                                                        CJoystickDriverPrimitive& right,
+                                                        CJoystickDriverPrimitive& left);
+    bool GetAccelerometer(const JoystickFeature& feature, CJoystickDriverPrimitive& positiveX,
+                                                          CJoystickDriverPrimitive& positiveY,
+                                                          CJoystickDriverPrimitive& positiveZ);
 
   private:
     typedef std::string Feature;
     typedef std::map<CJoystickDriverPrimitive, Feature> DriverMap;
 
     // Utility functions
-    static HatDirection       ToHatDirection(JOYSTICK_DRIVER_HAT_DIRECTION driverDirection);
-    static SemiAxisDirection  ToSemiAxisDirection(JOYSTICK_DRIVER_SEMIAXIS_DIRECTION dir);
-    static DriverMap          ToDriverMap(const JoystickFeatureMap& features);
+    static DriverMap                CreateLookupTable(const JoystickFeatureMap& features);
+    static CJoystickDriverPrimitive ToPrimitive(const ADDON::DriverPrimitive& primitive);
+    static HatDirection             ToHatDirection(JOYSTICK_DRIVER_HAT_DIRECTION driverDirection);
+    static SemiAxisDirection        ToSemiAxisDirection(JOYSTICK_DRIVER_SEMIAXIS_DIRECTION dir);
 
     CPeripheral* const  m_device;
     PeripheralAddonPtr  m_addon;

--- a/xbmc/peripherals/addons/AddonJoystickButtonMapWO.cpp
+++ b/xbmc/peripherals/addons/AddonJoystickButtonMapWO.cpp
@@ -46,19 +46,19 @@ bool CAddonJoystickButtonMapWO::MapButton(const ::JoystickFeature& feature, cons
     case DriverPrimitiveTypeButton:
     {
       ADDON::DriverButton driverButton(feature, primitive.Index());
-      retVal = m_addon->MapJoystickFeature(m_device, m_strControllerId, &driverButton);
+      retVal = m_addon->AddFeature(m_device, m_strControllerId, &driverButton);
       break;
     }
     case DriverPrimitiveTypeHatDirection:
     {
       ADDON::DriverHat driverHat(feature, primitive.Index(), ToHatDirection(primitive.HatDir()));
-      retVal = m_addon->MapJoystickFeature(m_device, m_strControllerId, &driverHat);
+      retVal = m_addon->AddFeature(m_device, m_strControllerId, &driverHat);
       break;
     }
     case DriverPrimitiveTypeSemiAxis:
     {
       ADDON::DriverSemiAxis driverSemiAxis(feature, primitive.Index(), ToSemiAxisDirection(primitive.SemiAxisDir()));
-      retVal = m_addon->MapJoystickFeature(m_device, m_strControllerId, &driverSemiAxis);
+      retVal = m_addon->AddFeature(m_device, m_strControllerId, &driverSemiAxis);
       break;
     }
     default:
@@ -76,7 +76,7 @@ bool CAddonJoystickButtonMapWO::MapAnalogStick(const ::JoystickFeature& feature,
                                              horizIndex, horizInverted,
                                              vertIndex,  vertInverted);
 
-  return m_addon->MapJoystickFeature(m_device, m_strControllerId, &driverAnalogStick);
+  return m_addon->AddFeature(m_device, m_strControllerId, &driverAnalogStick);
 }
 
 bool CAddonJoystickButtonMapWO::MapAccelerometer(const ::JoystickFeature& feature,
@@ -89,7 +89,7 @@ bool CAddonJoystickButtonMapWO::MapAccelerometer(const ::JoystickFeature& featur
                                                  yIndex, yInverted,
                                                  zIndex, zInverted);
 
-  return m_addon->MapJoystickFeature(m_device, m_strControllerId, &driverAccelerometer);
+  return m_addon->AddFeature(m_device, m_strControllerId, &driverAccelerometer);
 }
 
 JOYSTICK_DRIVER_HAT_DIRECTION CAddonJoystickButtonMapWO::ToHatDirection(HatDirection dir)

--- a/xbmc/peripherals/addons/AddonJoystickButtonMapWO.cpp
+++ b/xbmc/peripherals/addons/AddonJoystickButtonMapWO.cpp
@@ -37,28 +37,32 @@ bool CAddonJoystickButtonMapWO::Load(void)
   return m_addon.get() != NULL;
 }
 
-bool CAddonJoystickButtonMapWO::MapButton(const ::JoystickFeature& feature, const CJoystickDriverPrimitive& primitive)
+bool CAddonJoystickButtonMapWO::AddPrimitiveFeature(const ::JoystickFeature& feature, const CJoystickDriverPrimitive& primitive)
 {
-  bool retVal(false);
+  ADDON::PrimitiveFeature primitiveFeature(feature, ToPrimitive(primitive));
+
+  return m_addon->AddFeature(m_device, m_strControllerId, &primitiveFeature);
+}
+
+ADDON::DriverPrimitive CAddonJoystickButtonMapWO::ToPrimitive(const CJoystickDriverPrimitive& primitive)
+{
+  ADDON::DriverPrimitive retVal;
 
   switch (primitive.Type())
   {
     case DriverPrimitiveTypeButton:
     {
-      ADDON::DriverButton driverButton(feature, primitive.Index());
-      retVal = m_addon->AddFeature(m_device, m_strControllerId, &driverButton);
+      retVal = ADDON::DriverPrimitive(primitive.Index());
       break;
     }
     case DriverPrimitiveTypeHatDirection:
     {
-      ADDON::DriverHat driverHat(feature, primitive.Index(), ToHatDirection(primitive.HatDir()));
-      retVal = m_addon->AddFeature(m_device, m_strControllerId, &driverHat);
+      retVal = ADDON::DriverPrimitive(primitive.Index(), ToHatDirection(primitive.HatDir()));
       break;
     }
     case DriverPrimitiveTypeSemiAxis:
     {
-      ADDON::DriverSemiAxis driverSemiAxis(feature, primitive.Index(), ToSemiAxisDirection(primitive.SemiAxisDir()));
-      retVal = m_addon->AddFeature(m_device, m_strControllerId, &driverSemiAxis);
+      retVal = ADDON::DriverPrimitive(primitive.Index(), ToSemiAxisDirection(primitive.SemiAxisDir()));
       break;
     }
     default:
@@ -68,28 +72,28 @@ bool CAddonJoystickButtonMapWO::MapButton(const ::JoystickFeature& feature, cons
   return retVal;
 }
 
-bool CAddonJoystickButtonMapWO::MapAnalogStick(const ::JoystickFeature& feature,
-                                               int horizIndex, bool horizInverted,
-                                               int vertIndex,  bool vertInverted)
+bool CAddonJoystickButtonMapWO::AddAnalogStick(const ::JoystickFeature& feature,
+                                               const CJoystickDriverPrimitive& up,
+                                               const CJoystickDriverPrimitive& down,
+                                               const CJoystickDriverPrimitive& right,
+                                               const CJoystickDriverPrimitive& left)
 {
-  ADDON::DriverAnalogStick driverAnalogStick(feature,
-                                             horizIndex, horizInverted,
-                                             vertIndex,  vertInverted);
+  ADDON::AnalogStick analogStick(feature, ToPrimitive(up),    ToPrimitive(down),
+                                          ToPrimitive(right), ToPrimitive(left));
 
-  return m_addon->AddFeature(m_device, m_strControllerId, &driverAnalogStick);
+  return m_addon->AddFeature(m_device, m_strControllerId, &analogStick);
 }
 
-bool CAddonJoystickButtonMapWO::MapAccelerometer(const ::JoystickFeature& feature,
-                                                  int xIndex, bool xInverted,
-                                                  int yIndex, bool yInverted,
-                                                  int zIndex, bool zInverted)
+bool CAddonJoystickButtonMapWO::AddAccelerometer(const ::JoystickFeature& feature,
+                                                 const CJoystickDriverPrimitive& positiveX,
+                                                 const CJoystickDriverPrimitive& positiveY,
+                                                 const CJoystickDriverPrimitive& positiveZ)
 {
-  ADDON::DriverAccelerometer driverAccelerometer(feature,
-                                                 xIndex, xInverted,
-                                                 yIndex, yInverted,
-                                                 zIndex, zInverted);
+  ADDON::Accelerometer accelerometer(feature, ToPrimitive(positiveX),
+                                     ToPrimitive(positiveY),
+                                     ToPrimitive(positiveZ));
 
-  return m_addon->AddFeature(m_device, m_strControllerId, &driverAccelerometer);
+  return m_addon->AddFeature(m_device, m_strControllerId, &accelerometer);
 }
 
 JOYSTICK_DRIVER_HAT_DIRECTION CAddonJoystickButtonMapWO::ToHatDirection(HatDirection dir)

--- a/xbmc/peripherals/addons/AddonJoystickButtonMapWO.h
+++ b/xbmc/peripherals/addons/AddonJoystickButtonMapWO.h
@@ -37,15 +37,18 @@ namespace PERIPHERALS
 
     std::string ControllerID(void) const { return m_strControllerId; }
     bool Load(void);
-    bool MapButton(const JoystickFeature& feature, const CJoystickDriverPrimitive& primitive);
-    bool MapAnalogStick(const JoystickFeature& feature, int horizIndex, bool horizInverted,
-                                                        int vertIndex,  bool vertInverted);
-    bool MapAccelerometer(const JoystickFeature& feature, int xIndex, bool xInverted,
-                                                          int yIndex, bool yInverted,
-                                                          int zIndex, bool zInverted);
+    bool AddPrimitiveFeature(const JoystickFeature& feature, const CJoystickDriverPrimitive& primitive);
+    bool AddAnalogStick(const JoystickFeature& feature, const CJoystickDriverPrimitive& up,
+                                                        const CJoystickDriverPrimitive& down,
+                                                        const CJoystickDriverPrimitive& right,
+                                                        const CJoystickDriverPrimitive& left);
+    bool AddAccelerometer(const JoystickFeature& feature, const CJoystickDriverPrimitive& positiveX,
+                                                          const CJoystickDriverPrimitive& positiveY,
+                                                          const CJoystickDriverPrimitive& positiveZ);
 
   private:
     // Utility functions
+    static ADDON::DriverPrimitive             ToPrimitive(const CJoystickDriverPrimitive& primitive);
     static JOYSTICK_DRIVER_HAT_DIRECTION      ToHatDirection(HatDirection dir);
     static JOYSTICK_DRIVER_SEMIAXIS_DIRECTION ToSemiAxisDirection(SemiAxisDirection dir);
 

--- a/xbmc/peripherals/addons/PeripheralAddon.cpp
+++ b/xbmc/peripherals/addons/PeripheralAddon.cpp
@@ -471,8 +471,8 @@ bool CPeripheralAddon::GetJoystickProperties(unsigned int index, CPeripheralJoys
   return false;
 }
 
-bool CPeripheralAddon::GetButtonMap(const CPeripheral* device, const std::string& strControllerId,
-                                    JoystickFeatureMap& features)
+bool CPeripheralAddon::GetFeatures(const CPeripheral* device, const std::string& strControllerId,
+                                   JoystickFeatureMap& features)
 {
   if (!HasFeature(FEATURE_JOYSTICK))
     return false;
@@ -488,8 +488,8 @@ bool CPeripheralAddon::GetButtonMap(const CPeripheral* device, const std::string
   unsigned int      featureCount = 0;
   JOYSTICK_FEATURE* pFeatures = NULL;
 
-  try { LogError(retVal = m_pStruct->GetButtonMap(&joystickStruct, strControllerId.c_str(),
-                                                  &featureCount, &pFeatures), "GetButtonMap()"); }
+  try { LogError(retVal = m_pStruct->GetFeatures(&joystickStruct, strControllerId.c_str(),
+                                                 &featureCount, &pFeatures), "GetFeatures()"); }
   catch (std::exception &e) { LogException(e, "GetButtonMap()"); return false;  }
 
   if (retVal == PERIPHERAL_NO_ERROR)
@@ -501,8 +501,8 @@ bool CPeripheralAddon::GetButtonMap(const CPeripheral* device, const std::string
         features[feature->Name()] = feature;
     }
 
-    try { m_pStruct->FreeButtonMap(featureCount, pFeatures); }
-    catch (std::exception &e) { LogException(e, "FreeButtonMap()"); }
+    try { m_pStruct->FreeFeatures(featureCount, pFeatures); }
+    catch (std::exception &e) { LogException(e, "FreeFeatures()"); }
 
     return true;
   }
@@ -510,8 +510,8 @@ bool CPeripheralAddon::GetButtonMap(const CPeripheral* device, const std::string
   return false;
 }
 
-bool CPeripheralAddon::MapJoystickFeature(const CPeripheral* device, const std::string& strControllerId,
-                                          const ADDON::JoystickFeature* feature)
+bool CPeripheralAddon::AddFeature(const CPeripheral* device, const std::string& strControllerId,
+                                  const ADDON::JoystickFeature* feature)
 {
   if (!HasFeature(FEATURE_JOYSTICK))
     return false;
@@ -527,9 +527,9 @@ bool CPeripheralAddon::MapJoystickFeature(const CPeripheral* device, const std::
   JOYSTICK_FEATURE featureStruct;
   feature->ToStruct(featureStruct);
 
-  try { LogError(retVal = m_pStruct->MapJoystickFeature(&joystickStruct, strControllerId.c_str(),
-                                                        &featureStruct), "MapJoystickFeature()"); }
-  catch (std::exception &e) { LogException(e, "MapJoystickFeature()"); return false;  }
+  try { LogError(retVal = m_pStruct->AddFeature(&joystickStruct, strControllerId.c_str(),
+                                                &featureStruct), "AddFeature()"); }
+  catch (std::exception &e) { LogException(e, "AddFeature()"); return false;  }
 
   if (retVal == PERIPHERAL_NO_ERROR)
   {

--- a/xbmc/peripherals/addons/PeripheralAddon.h
+++ b/xbmc/peripherals/addons/PeripheralAddon.h
@@ -80,8 +80,8 @@ namespace PERIPHERALS
     /** @name Joystick methods */
     //@{
     bool GetJoystickProperties(unsigned int index, CPeripheralJoystick& joystick);
-    bool GetButtonMap(const CPeripheral* device, const std::string& strControllerId, JoystickFeatureMap& features);
-    bool MapJoystickFeature(const CPeripheral* device, const std::string& strControllerId, const ADDON::JoystickFeature* feature);
+    bool GetFeatures(const CPeripheral* device, const std::string& strControllerId, JoystickFeatureMap& features);
+    bool AddFeature(const CPeripheral* device, const std::string& strControllerId, const ADDON::JoystickFeature* feature);
     //@}
 
     void RegisterButtonMap(CPeripheral* device, IJoystickButtonMap* buttonMap);


### PR DESCRIPTION
This is a notice of a breaking change to the peripheral API. Make sure everything is up to date!

This is the first step to allowing buttons/keys to emulate an analog stick. The next step requires some modifications to the controller mapping GUI, so I'm going to roll that into my configuration utility refactor