### PR TITLE
[retroplayer] Add window mapping 'fullscreengame'

### DIFF
--- a/xbmc/input/ButtonTranslator.cpp
+++ b/xbmc/input/ButtonTranslator.cpp
@@ -405,6 +405,7 @@ static const ActionMapping windows[] =
         {"fullscreenvideo"          , WINDOW_FULLSCREEN_VIDEO},
         {"fullscreenlivetv"         , WINDOW_FULLSCREEN_LIVETV}, // virtual window/keymap section for PVR specific bindings in fullscreen playback (which internally uses WINDOW_FULLSCREEN_VIDEO)
         {"fullscreenradio"          , WINDOW_FULLSCREEN_RADIO}, // virtual window for fullscreen radio, uses WINDOW_VISUALISATION as fallback
+        {"fullscreengame"           , WINDOW_FULLSCREEN_GAME}, // virtual window/keymap section for game specific bindings in fullscreen playback (which internally uses WINDOW_FULLSCREEN_VIDEO)
         {"visualisation"            , WINDOW_VISUALISATION},
         {"slideshow"                , WINDOW_SLIDESHOW},
         {"filestackingdialog"       , WINDOW_DIALOG_FILESTACKING},
@@ -459,6 +460,7 @@ static const ActionMapping touchcommands[] =
 static const WindowMapping fallbackWindows[] =
 {
   { WINDOW_FULLSCREEN_LIVETV,          WINDOW_FULLSCREEN_VIDEO },
+  { WINDOW_FULLSCREEN_GAME,            WINDOW_FULLSCREEN_VIDEO },
   { WINDOW_FULLSCREEN_RADIO,           WINDOW_VISUALISATION    }
 };
 


### PR DESCRIPTION
This commit adds a window mapping entry for 'fullscreengame' to the ButtonTranslator so that keymaps can be written for full screen gaming.

A fallback to 'fullscreenvideo' ensures that when the keymap does not contain a specific section for 'fullscreengame', it uses the 'fullscreenvideo' mapping.
This way without additional configuration, a remote can be used in parallel with the gamepad for example to show the OSD menu.