### PR TITLE
[gameclient] Fix broken audio in some cores

### DIFF
--- a/xbmc/games/addons/GameClient.cpp
+++ b/xbmc/games/addons/GameClient.cpp
@@ -622,14 +622,14 @@ void CGameClient::CloseStream(GAME_STREAM_TYPE stream)
   {
   case GAME_STREAM_AUDIO:
   {
-    if (m_video)
-      m_video->CloseStream();
+    if (m_audio)
+      m_audio->CloseStream();
     break;
   }
   case GAME_STREAM_VIDEO:
   {
-    if (m_audio)
-      m_audio->CloseStream();
+    if (m_video)
+      m_video->CloseStream();
     break;
   }
   default:


### PR DESCRIPTION
@garbear: I was able to track down and fix the missing audio problem in the scummvm core. (mentioned in https://github.com/kodi-game/game.libretro.scummvm/pull/1)
Looks like a c&p error to me, the code closed the wrong stream type.

EDIT: tested on linux, cross checked with bsnes-mercury-balanced (where audio is still working with the patch)

With scummvm working, retroplayer can be considered done (at least for people born in the 80s) :D