### PR TITLE
[games] Mouse support

### DIFF
--- a/Kodi.xcodeproj/project.pbxproj
+++ b/Kodi.xcodeproj/project.pbxproj
@@ -253,6 +253,10 @@
 		5EB3113C1A978B9B00551907 /* CueInfoLoader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 5EB3113A1A978B9B00551907 /* CueInfoLoader.cpp */; };
 		5EE4F9181A9FF36F002E20F8 /* CueInfoLoader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 5EB3113A1A978B9B00551907 /* CueInfoLoader.cpp */; };
 		5EF801001A97892A0035AA4D /* ReplayGain.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 5EF800FE1A97892A0035AA4D /* ReplayGain.cpp */; };
+		6800042B1DC52789009E481A /* GameClientMouse.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 680004291DC52789009E481A /* GameClientMouse.cpp */; };
+		6800042C1DC52789009E481A /* GameClientMouse.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 680004291DC52789009E481A /* GameClientMouse.cpp */; };
+		681073F51DC72796001B0F60 /* MouseInputHandling.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 681073F31DC72796001B0F60 /* MouseInputHandling.cpp */; };
+		681073F61DC72796001B0F60 /* MouseInputHandling.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 681073F31DC72796001B0F60 /* MouseInputHandling.cpp */; };
 		6815C1411CC7BADB000DB91A /* RumbleGenerator.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 6815C13F1CC7BADB000DB91A /* RumbleGenerator.cpp */; };
 		6815C1421CC7BADB000DB91A /* RumbleGenerator.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 6815C13F1CC7BADB000DB91A /* RumbleGenerator.cpp */; };
 		6818418C1CE81BC300B460E4 /* GUIDialogSelectGameClient.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 6818418A1CE81BC300B460E4 /* GUIDialogSelectGameClient.cpp */; };
@@ -393,12 +397,14 @@
 		68D77D6D1CD1C86B004C1735 /* RetroPlayerAudio.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 68D77D641CD1C86B004C1735 /* RetroPlayerAudio.cpp */; };
 		68D77D6E1CD1C86B004C1735 /* RetroPlayerVideo.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 68D77D661CD1C86B004C1735 /* RetroPlayerVideo.cpp */; };
 		68D77D6F1CD1C86B004C1735 /* RetroPlayerVideo.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 68D77D661CD1C86B004C1735 /* RetroPlayerVideo.cpp */; };
-		68DE2BEB1CDEBAC9002EA0F7 /* Savestate.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 68DE2BE71CDEBAC9002EA0F7 /* Savestate.cpp */; };
-		68DE2BEC1CDEBAC9002EA0F7 /* Savestate.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 68DE2BE71CDEBAC9002EA0F7 /* Savestate.cpp */; };
 		68D77D751CD1C89A004C1735 /* GUIViewStateWindowGames.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 68D77D711CD1C89A004C1735 /* GUIViewStateWindowGames.cpp */; };
 		68D77D761CD1C89A004C1735 /* GUIViewStateWindowGames.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 68D77D711CD1C89A004C1735 /* GUIViewStateWindowGames.cpp */; };
 		68D77D771CD1C89A004C1735 /* GUIWindowGames.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 68D77D731CD1C89A004C1735 /* GUIWindowGames.cpp */; };
 		68D77D781CD1C89A004C1735 /* GUIWindowGames.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 68D77D731CD1C89A004C1735 /* GUIWindowGames.cpp */; };
+		68DE2BEB1CDEBAC9002EA0F7 /* Savestate.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 68DE2BE71CDEBAC9002EA0F7 /* Savestate.cpp */; };
+		68DE2BEC1CDEBAC9002EA0F7 /* Savestate.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 68DE2BE71CDEBAC9002EA0F7 /* Savestate.cpp */; };
+		68E68CB21DC71B6500712EC5 /* MouseWindowingButtonMap.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 68E68CB01DC71B6500712EC5 /* MouseWindowingButtonMap.cpp */; };
+		68E68CB31DC71B6500712EC5 /* MouseWindowingButtonMap.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 68E68CB01DC71B6500712EC5 /* MouseWindowingButtonMap.cpp */; };
 		761170901C8B85F8006C6366 /* AddonGUIRenderingControl.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7611708C1C8B85F8006C6366 /* AddonGUIRenderingControl.cpp */; };
 		761170911C8B85F8006C6366 /* AddonGUIWindow.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7611708E1C8B85F8006C6366 /* AddonGUIWindow.cpp */; };
 		76AEFB361C8F79BD00EF2EC0 /* AddonInterfaces.cpp in Sources */ = {isa = PBXBuildFile; fileRef = EDED2E991C878F61000F5E80 /* AddonInterfaces.cpp */; };
@@ -2838,6 +2844,10 @@
 		5EB3113B1A978B9B00551907 /* CueInfoLoader.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CueInfoLoader.h; sourceTree = "<group>"; };
 		5EF800FE1A97892A0035AA4D /* ReplayGain.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ReplayGain.cpp; sourceTree = "<group>"; };
 		5EF800FF1A97892A0035AA4D /* ReplayGain.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ReplayGain.h; sourceTree = "<group>"; };
+		680004291DC52789009E481A /* GameClientMouse.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = GameClientMouse.cpp; path = games/addons/GameClientMouse.cpp; sourceTree = "<group>"; };
+		6800042A1DC52789009E481A /* GameClientMouse.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = GameClientMouse.h; path = games/addons/GameClientMouse.h; sourceTree = "<group>"; };
+		681073F31DC72796001B0F60 /* MouseInputHandling.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = MouseInputHandling.cpp; path = mouse/generic/MouseInputHandling.cpp; sourceTree = "<group>"; };
+		681073F41DC72796001B0F60 /* MouseInputHandling.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = MouseInputHandling.h; path = mouse/generic/MouseInputHandling.h; sourceTree = "<group>"; };
 		6815C13F1CC7BADB000DB91A /* RumbleGenerator.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = RumbleGenerator.cpp; path = joysticks/RumbleGenerator.cpp; sourceTree = "<group>"; };
 		6815C1401CC7BADB000DB91A /* RumbleGenerator.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = RumbleGenerator.h; path = joysticks/RumbleGenerator.h; sourceTree = "<group>"; };
 		6818418A1CE81BC300B460E4 /* GUIDialogSelectGameClient.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = GUIDialogSelectGameClient.cpp; path = games/dialogs/GUIDialogSelectGameClient.cpp; sourceTree = "<group>"; };
@@ -2846,6 +2856,8 @@
 		682846281CF3E6B200087028 /* GameClientRealtimePlayback.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = GameClientRealtimePlayback.h; path = games/addons/playback/GameClientRealtimePlayback.h; sourceTree = "<group>"; };
 		6838CF7F1D6665510057F17B /* DeadzoneFilter.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = DeadzoneFilter.cpp; path = joysticks/DeadzoneFilter.cpp; sourceTree = "<group>"; };
 		6838CF801D6665510057F17B /* DeadzoneFilter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = DeadzoneFilter.h; path = joysticks/DeadzoneFilter.h; sourceTree = "<group>"; };
+		685DEEF41DC6AF6E00EA9AB7 /* IMouseDriverHandler.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = IMouseDriverHandler.h; path = mouse/IMouseDriverHandler.h; sourceTree = "<group>"; };
+		685DEEF51DC6AF6E00EA9AB7 /* IMouseInputHandler.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = IMouseInputHandler.h; path = mouse/IMouseInputHandler.h; sourceTree = "<group>"; };
 		6861B9E81CC248EE00F62655 /* DriverReceiving.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = DriverReceiving.cpp; path = joysticks/generic/DriverReceiving.cpp; sourceTree = "<group>"; };
 		6861B9E91CC248EE00F62655 /* DriverReceiving.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = DriverReceiving.h; path = joysticks/generic/DriverReceiving.h; sourceTree = "<group>"; };
 		6861B9EC1CC248F600F62655 /* IDriverReceiver.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = IDriverReceiver.h; path = joysticks/IDriverReceiver.h; sourceTree = "<group>"; };
@@ -2938,9 +2950,9 @@
 		68B054C51CD819B100726629 /* IMemoryStream.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = IMemoryStream.h; path = games/addons/savestates/IMemoryStream.h; sourceTree = "<group>"; };
 		68B054C61CD819B100726629 /* LinearMemoryStream.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = LinearMemoryStream.cpp; path = games/addons/savestates/LinearMemoryStream.cpp; sourceTree = "<group>"; };
 		68B054C71CD819B100726629 /* LinearMemoryStream.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = LinearMemoryStream.h; path = games/addons/savestates/LinearMemoryStream.h; sourceTree = "<group>"; };
+		68B1E8831D35A9AC000D1A46 /* RetroPlayerDefines.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = RetroPlayerDefines.h; path = RetroPlayer/RetroPlayerDefines.h; sourceTree = "<group>"; };
 		68B7E5E61D5FA9B300A5AEC0 /* GUIFeatureControls.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = GUIFeatureControls.cpp; path = games/controllers/guicontrols/GUIFeatureControls.cpp; sourceTree = "<group>"; };
 		68B7E5E71D5FA9B300A5AEC0 /* GUIFeatureControls.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = GUIFeatureControls.h; path = games/controllers/guicontrols/GUIFeatureControls.h; sourceTree = "<group>"; };
-		68B1E8831D35A9AC000D1A46 /* RetroPlayerDefines.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = RetroPlayerDefines.h; path = RetroPlayer/RetroPlayerDefines.h; sourceTree = "<group>"; };
 		68C1495F1CDDF0B60014ADDB /* SavestateDatabase.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = SavestateDatabase.cpp; path = games/addons/savestates/SavestateDatabase.cpp; sourceTree = "<group>"; };
 		68C149601CDDF0B60014ADDB /* SavestateDatabase.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SavestateDatabase.h; path = games/addons/savestates/SavestateDatabase.h; sourceTree = "<group>"; };
 		68C149611CDDF0B60014ADDB /* SavestateDefines.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SavestateDefines.h; path = games/addons/savestates/SavestateDefines.h; sourceTree = "<group>"; };
@@ -3012,12 +3024,15 @@
 		68D77D651CD1C86B004C1735 /* RetroPlayerAudio.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = RetroPlayerAudio.h; path = RetroPlayer/RetroPlayerAudio.h; sourceTree = "<group>"; };
 		68D77D661CD1C86B004C1735 /* RetroPlayerVideo.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = RetroPlayerVideo.cpp; path = RetroPlayer/RetroPlayerVideo.cpp; sourceTree = "<group>"; };
 		68D77D671CD1C86B004C1735 /* RetroPlayerVideo.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = RetroPlayerVideo.h; path = RetroPlayer/RetroPlayerVideo.h; sourceTree = "<group>"; };
-		68DE2BE71CDEBAC9002EA0F7 /* Savestate.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Savestate.cpp; path = games/addons/savestates/Savestate.cpp; sourceTree = "<group>"; };
-		68DE2BE81CDEBAC9002EA0F7 /* Savestate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Savestate.h; path = games/addons/savestates/Savestate.h; sourceTree = "<group>"; };
 		68D77D711CD1C89A004C1735 /* GUIViewStateWindowGames.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = GUIViewStateWindowGames.cpp; path = games/windows/GUIViewStateWindowGames.cpp; sourceTree = "<group>"; };
 		68D77D721CD1C89A004C1735 /* GUIViewStateWindowGames.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = GUIViewStateWindowGames.h; path = games/windows/GUIViewStateWindowGames.h; sourceTree = "<group>"; };
 		68D77D731CD1C89A004C1735 /* GUIWindowGames.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = GUIWindowGames.cpp; path = games/windows/GUIWindowGames.cpp; sourceTree = "<group>"; };
 		68D77D741CD1C89A004C1735 /* GUIWindowGames.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = GUIWindowGames.h; path = games/windows/GUIWindowGames.h; sourceTree = "<group>"; };
+		68DE2BE71CDEBAC9002EA0F7 /* Savestate.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Savestate.cpp; path = games/addons/savestates/Savestate.cpp; sourceTree = "<group>"; };
+		68DE2BE81CDEBAC9002EA0F7 /* Savestate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Savestate.h; path = games/addons/savestates/Savestate.h; sourceTree = "<group>"; };
+		68E68CA31DC70B5200712EC5 /* IMouseButtonMap.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = IMouseButtonMap.h; path = mouse/IMouseButtonMap.h; sourceTree = "<group>"; };
+		68E68CB01DC71B6500712EC5 /* MouseWindowingButtonMap.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = MouseWindowingButtonMap.cpp; path = mouse/MouseWindowingButtonMap.cpp; sourceTree = "<group>"; };
+		68E68CB11DC71B6500712EC5 /* MouseWindowingButtonMap.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = MouseWindowingButtonMap.h; path = mouse/MouseWindowingButtonMap.h; sourceTree = "<group>"; };
 		6E97BDBF0DA2B620003A2A89 /* EventClient.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = EventClient.h; sourceTree = "<group>"; };
 		6E97BDC00DA2B620003A2A89 /* EventPacket.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = EventPacket.h; sourceTree = "<group>"; };
 		6E97BDC10DA2B620003A2A89 /* EventServer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = EventServer.h; sourceTree = "<group>"; };
@@ -5649,6 +5664,7 @@
 			children = (
 				68AE5BAB1C92419500C4D527 /* joysticks */,
 				68D77D011CD1C627004C1735 /* keyboard */,
+				6800042D1DC52795009E481A /* mouse */,
 				E4991332174E5E5C00741B6D /* touch */,
 				18B7C8CB12942546009E7A26 /* ButtonTranslator.cpp */,
 				18B7C8CC12942546009E7A26 /* ButtonTranslator.h */,
@@ -6324,6 +6340,28 @@
 			path = osx;
 			sourceTree = "<group>";
 		};
+		6800042D1DC52795009E481A /* mouse */ = {
+			isa = PBXGroup;
+			children = (
+				681073F21DC72788001B0F60 /* generic */,
+				68E68CA31DC70B5200712EC5 /* IMouseButtonMap.h */,
+				685DEEF41DC6AF6E00EA9AB7 /* IMouseDriverHandler.h */,
+				685DEEF51DC6AF6E00EA9AB7 /* IMouseInputHandler.h */,
+				68E68CB01DC71B6500712EC5 /* MouseWindowingButtonMap.cpp */,
+				68E68CB11DC71B6500712EC5 /* MouseWindowingButtonMap.h */,
+			);
+			name = mouse;
+			sourceTree = "<group>";
+		};
+		681073F21DC72788001B0F60 /* generic */ = {
+			isa = PBXGroup;
+			children = (
+				681073F31DC72796001B0F60 /* MouseInputHandling.cpp */,
+				681073F41DC72796001B0F60 /* MouseInputHandling.h */,
+			);
+			name = generic;
+			sourceTree = "<group>";
+		};
 		68AE5BA21C92410300C4D527 /* Peripheral */ = {
 			isa = PBXGroup;
 			children = (
@@ -6561,6 +6599,8 @@
 				68D77D2B1CD1C7EB004C1735 /* GameClientInput.h */,
 				68CEE4741DC02A1900F477CA /* GameClientKeyboard.cpp */,
 				68CEE4751DC02A1900F477CA /* GameClientKeyboard.h */,
+				680004291DC52789009E481A /* GameClientMouse.cpp */,
+				6800042A1DC52789009E481A /* GameClientMouse.h */,
 				68D77D2C1CD1C7EB004C1735 /* GameClientProperties.cpp */,
 				68D77D2D1CD1C7EB004C1735 /* GameClientProperties.h */,
 				68D77D2E1CD1C7EB004C1735 /* GameClientTiming.cpp */,
@@ -6595,23 +6635,6 @@
 			name = playback;
 			sourceTree = "<group>";
 		};
-		76EC19BB1D15510D00D4AF19 /* AudioDSPAddons */ = {
-			isa = PBXGroup;
-			children = (
-				76EC19BC1D15514200D4AF19 /* ActiveAEDSP.cpp */,
-				76EC19BD1D15514200D4AF19 /* ActiveAEDSP.h */,
-				76EC19BE1D15514200D4AF19 /* ActiveAEDSPAddon.cpp */,
-				76EC19BF1D15514200D4AF19 /* ActiveAEDSPAddon.h */,
-				76EC19C01D15514200D4AF19 /* ActiveAEDSPDatabase.cpp */,
-				76EC19C11D15514200D4AF19 /* ActiveAEDSPDatabase.h */,
-				76EC19C21D15514200D4AF19 /* ActiveAEDSPMode.cpp */,
-				76EC19C31D15514200D4AF19 /* ActiveAEDSPMode.h */,
-				76EC19C41D15514200D4AF19 /* ActiveAEDSPProcess.cpp */,
-				76EC19C51D15514200D4AF19 /* ActiveAEDSPProcess.h */,
-			);
-			name = AudioDSPAddons;
-			sourceTree = "<group>";
-		};
 		68D77D5F1CD1C841004C1735 /* RetroPlayer */ = {
 			isa = PBXGroup;
 			children = (
@@ -6638,6 +6661,23 @@
 				68D77D741CD1C89A004C1735 /* GUIWindowGames.h */,
 			);
 			name = windows;
+			sourceTree = "<group>";
+		};
+		76EC19BB1D15510D00D4AF19 /* AudioDSPAddons */ = {
+			isa = PBXGroup;
+			children = (
+				76EC19BC1D15514200D4AF19 /* ActiveAEDSP.cpp */,
+				76EC19BD1D15514200D4AF19 /* ActiveAEDSP.h */,
+				76EC19BE1D15514200D4AF19 /* ActiveAEDSPAddon.cpp */,
+				76EC19BF1D15514200D4AF19 /* ActiveAEDSPAddon.h */,
+				76EC19C01D15514200D4AF19 /* ActiveAEDSPDatabase.cpp */,
+				76EC19C11D15514200D4AF19 /* ActiveAEDSPDatabase.h */,
+				76EC19C21D15514200D4AF19 /* ActiveAEDSPMode.cpp */,
+				76EC19C31D15514200D4AF19 /* ActiveAEDSPMode.h */,
+				76EC19C41D15514200D4AF19 /* ActiveAEDSPProcess.cpp */,
+				76EC19C51D15514200D4AF19 /* ActiveAEDSPProcess.h */,
+			);
+			name = AudioDSPAddons;
 			sourceTree = "<group>";
 		};
 		76F4C37B1C8E927A00A1E64B /* InputStream */ = {
@@ -10486,6 +10526,7 @@
 				E36C29E00DA72429001F0C9D /* Album.cpp in Sources */,
 				E36C29E60DA72442001F0C9D /* DVDSubtitleParserSami.cpp in Sources */,
 				E36C29EA0DA72486001F0C9D /* ScraperUrl.cpp in Sources */,
+				68E68CB21DC71B6500712EC5 /* MouseWindowingButtonMap.cpp in Sources */,
 				E36C29EB0DA72486001F0C9D /* MusicArtistInfo.cpp in Sources */,
 				E36C29EC0DA72486001F0C9D /* Fanart.cpp in Sources */,
 				880DBE4E0DC223FF00E26B71 /* MediaSource.cpp in Sources */,
@@ -10642,6 +10683,7 @@
 				18B7C7BF1294222E009E7A26 /* GUIFixedListContainer.cpp in Sources */,
 				18B7C7C01294222E009E7A26 /* GUIFont.cpp in Sources */,
 				18B7C7C11294222E009E7A26 /* GUIFontManager.cpp in Sources */,
+				6800042B1DC52789009E481A /* GameClientMouse.cpp in Sources */,
 				18B7C7C21294222E009E7A26 /* GUIFontTTF.cpp in Sources */,
 				18B7C7C31294222E009E7A26 /* GUIFontTTFDX.cpp in Sources */,
 				DF209C121DB2A0C300515D1F /* FilesystemInstaller.cpp in Sources */,
@@ -10685,6 +10727,7 @@
 				18B7C7E71294222E009E7A26 /* GUITextureGL.cpp in Sources */,
 				18B7C7E81294222E009E7A26 /* GUITextureGLES.cpp in Sources */,
 				18B7C7E91294222E009E7A26 /* GUIToggleButtonControl.cpp in Sources */,
+				681073F51DC72796001B0F60 /* MouseInputHandling.cpp in Sources */,
 				18B7C7EA1294222E009E7A26 /* GUIVideoControl.cpp in Sources */,
 				18B7C7EB1294222E009E7A26 /* GUIVisualisationControl.cpp in Sources */,
 				18B7C7EC1294222E009E7A26 /* GUIWindow.cpp in Sources */,
@@ -11336,6 +11379,7 @@
 				E4991185174E5CE000741B6D /* GUIViewStateAddonBrowser.cpp in Sources */,
 				68B054CB1CD819B100726629 /* DeltaPairMemoryStream.cpp in Sources */,
 				E4991186174E5CE000741B6D /* GUIWindowAddonBrowser.cpp in Sources */,
+				68E68CB31DC71B6500712EC5 /* MouseWindowingButtonMap.cpp in Sources */,
 				E4991187174E5CE000741B6D /* PluginSource.cpp in Sources */,
 				E4991188174E5CE000741B6D /* Repository.cpp in Sources */,
 				E4991189174E5CE000741B6D /* Scraper.cpp in Sources */,
@@ -12363,6 +12407,7 @@
 				7CCDA7DA192756250074CF51 /* NptJson.cpp in Sources */,
 				DFD717371C09FEC60025D964 /* AutoPool.mm in Sources */,
 				7CCDA7DD192756250074CF51 /* NptList.cpp in Sources */,
+				681073F61DC72796001B0F60 /* MouseInputHandling.cpp in Sources */,
 				7C8E02291BA35D0B0072E8B2 /* GUIBuiltins.cpp in Sources */,
 				68AE5C321C9243A000C4D527 /* ControllerLayout.cpp in Sources */,
 				7CCDA7E6192756250074CF51 /* NptLogging.cpp in Sources */,
@@ -12412,6 +12457,7 @@
 				7C908895196358A8003D0619 /* auto_buffer.cpp in Sources */,
 				7CF34DA01930264A00D543C5 /* AudioEncoder.cpp in Sources */,
 				395C29F71A98B44B00EBC7AD /* AddonModuleXbmcwsgi.cpp in Sources */,
+				6800042C1DC52789009E481A /* GameClientMouse.cpp in Sources */,
 				7CF80DCA19710DC2003B2B34 /* KeyboardLayout.cpp in Sources */,
 				DFACDB891D6CAC33003BBB92 /* PlatformDarwin.cpp in Sources */,
 				B179BD6C1AD8EA7B00EA8D49 /* InputCodingTableBaiduPY.cpp in Sources */,

--- a/addons/kodi.game/addon.xml
+++ b/addons/kodi.game/addon.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<addon id="kodi.game" version="1.0.27" provider-name="Team-Kodi">
-	<backwards-compatibility abi="1.0.26"/>
+<addon id="kodi.game" version="1.0.28" provider-name="Team-Kodi">
+	<backwards-compatibility abi="1.0.28"/>
 	<requires>
 		<import addon="xbmc.core" version="0.1.0"/>
 	</requires>

--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -16329,7 +16329,17 @@ msgctxt "#35102"
 msgid "Disable joystick when this device is present"
 msgstr ""
 
-#empty strings from id 35103 to 35196
+#. Label for mouse buttons. Used in the controller mapping dialog.
+msgctxt "#35103"
+msgid "Buttons"
+msgstr ""
+
+#. Label for relative mounters like the mouse pointer. Used in the controller mapping dialog.
+msgctxt "#35104"
+msgid "Pointers"
+msgstr ""
+
+#empty strings from id 35105 to 35196
 
 #: system/settings/settings.xml
 msgctxt "#35197"

--- a/project/cmake/scripts/linux/Install.cmake
+++ b/project/cmake/scripts/linux/Install.cmake
@@ -154,6 +154,7 @@ install(FILES ${CORE_SOURCE_DIR}/xbmc/addons/kodi-addon-dev-kit/include/kodi/kod
               ${CORE_SOURCE_DIR}/xbmc/addons/kodi-addon-dev-kit/include/kodi/xbmc_codec_types.h
               ${CORE_SOURCE_DIR}/xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxPacket.h
               ${CORE_SOURCE_DIR}/xbmc/filesystem/IFileTypes.h
+              ${CORE_SOURCE_DIR}/xbmc/input/XBMC_vkeys.h
         DESTINATION ${includedir}/${APP_NAME_LC}
         COMPONENT kodi-addon-dev)
 

--- a/project/cmake/treedata/common/subdirs.txt
+++ b/project/cmake/treedata/common/subdirs.txt
@@ -20,6 +20,8 @@ xbmc/input/joysticks                            input/joysticks
 xbmc/input/joysticks/generic                    input/joysticks/generic
 xbmc/input/keyboard                             input/keyboard
 xbmc/input/keyboard/generic                     input/keyboard/generic
+xbmc/input/mouse                                input/mouse
+xbmc/input/mouse/generic                        input/mouse/generic
 xbmc/listproviders                              listproviders
 xbmc/media                                      media
 xbmc/messaging                                  messaging

--- a/xbmc/addons/addon-bindings.mk
+++ b/xbmc/addons/addon-bindings.mk
@@ -43,3 +43,4 @@ BINDINGS+=xbmc/addons/kodi-addon-dev-kit/include/kodi/libXBMC_codec.h
 BINDINGS+=xbmc/cores/VideoPlayer/DVDDemuxers/DVDDemuxPacket.h
 BINDINGS+=xbmc/cores/AudioEngine/Utils/AEChannelData.h
 BINDINGS+=xbmc/filesystem/IFileTypes.h
+BINDINGS+=xbmc/input/XBMC_vkeys.h

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/kodi_game_callbacks.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/kodi_game_callbacks.h
@@ -125,9 +125,11 @@ typedef struct CB_GameLib
   // --- Input callbacks -------------------------------------------------------
 
   /*!
-   * \brief Begin reporting events for the specified port
+   * \brief Begin reporting events for the specified joystick port
    *
    * \param port The zero-indexed port number
+   *
+   * \return true if the port was opened, false otherwise
    */
   bool (*OpenPort)(void* addonData, unsigned int port);
 

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/kodi_game_dll.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/kodi_game_dll.h
@@ -157,11 +157,11 @@ GAME_ERROR HwContextDestroy(void);
  *
  * Ports can be opened using the OpenPort() callback
  *
- * \param port The port number passed to OpenPort()
+ * \param port Non-negative for a joystick port, or GAME_INPUT_PORT value otherwise
  * \param collected True if a controller was connected, false if disconnected
  * \param controller The connected controller
  */
-void UpdatePort(unsigned int port, bool connected, const game_controller* controller);
+void UpdatePort(int port, bool connected, const game_controller* controller);
 
 /*!
  * \brief Check if input is accepted for a feature on the controller

--- a/xbmc/addons/kodi-addon-dev-kit/include/kodi/kodi_game_types.h
+++ b/xbmc/addons/kodi-addon-dev-kit/include/kodi/kodi_game_types.h
@@ -21,10 +21,10 @@
 #define KODI_GAME_TYPES_H_
 
 /* current game API version */
-#define GAME_API_VERSION                "1.0.27"
+#define GAME_API_VERSION                "1.0.28"
 
 /* min. game API version */
-#define GAME_MIN_API_VERSION            "1.0.26"
+#define GAME_MIN_API_VERSION            "1.0.28"
 
 #include <stddef.h>
 #include <stdint.h>
@@ -54,6 +54,12 @@
 #if !defined(ATTRIBUTE_PACKED)
   #define ATTRIBUTE_PACKED
   #define PRAGMA_PACK 1
+#endif
+
+#ifdef BUILD_KODI_ADDON
+#include "XBMC_vkeys.h"
+#else
+#include "input/XBMC_vkeys.h"
 #endif
 
 #ifdef __cplusplus
@@ -157,6 +163,13 @@ typedef enum GAME_HW_CONTEXT_TYPE
   GAME_HW_CONTEXT_OPENGL_CORE, // Modern desktop core GL context. Use major/minor fields to set GL version
   GAME_HW_CONTEXT_OPENGLES3,   // GLES 3.0
 } GAME_HW_CONTEXT_TYPE;
+
+typedef enum GAME_INPUT_PORT
+{
+  GAME_INPUT_PORT_JOYSTICK_START = 0, // Non-negative values are for joystick ports
+  GAME_INPUT_PORT_KEYBOARD = -1,
+  GAME_INPUT_PORT_MOUSE = -2,
+} GAME_INPUT_PORT;
 
 typedef enum GAME_INPUT_EVENT_SOURCE
 {
@@ -307,7 +320,7 @@ typedef struct game_accelerometer_event
 typedef struct game_key_event
 {
   bool         pressed;
-  uint32_t     character; // text character of the pressed key (UTF-32)
+  XBMCVKey     character;
   GAME_KEY_MOD modifiers;
 } ATTRIBUTE_PACKED game_key_event;
 
@@ -456,7 +469,7 @@ typedef struct GameClient
   GAME_ERROR  (__cdecl* Reset)(void);
   GAME_ERROR  (__cdecl* HwContextReset)(void);
   GAME_ERROR  (__cdecl* HwContextDestroy)(void);
-  void        (__cdecl* UpdatePort)(unsigned int, bool, const game_controller*);
+  void        (__cdecl* UpdatePort)(int, bool, const game_controller*);
   bool        (__cdecl* HasFeature)(const char* controller_id, const char* feature_name);
   bool        (__cdecl* InputEvent)(const game_input_event*);
   size_t      (__cdecl* SerializeSize)(void);

--- a/xbmc/games/addons/CMakeLists.txt
+++ b/xbmc/games/addons/CMakeLists.txt
@@ -1,6 +1,7 @@
 set(SOURCES GameClient.cpp
             GameClientInput.cpp
             GameClientKeyboard.cpp
+            GameClientMouse.cpp
             GameClientProperties.cpp
             GameClientTiming.cpp
             GameClientTranslator.cpp)
@@ -9,6 +10,7 @@ set(HEADERS GameClient.h
             GameClientCallbacks.h
             GameClientInput.h
             GameClientKeyboard.h
+            GameClientMouse.h
             GameClientProperties.h
             GameClientTiming.h
             GameClientTranslator.h)

--- a/xbmc/games/addons/GameClient.h
+++ b/xbmc/games/addons/GameClient.h
@@ -42,6 +42,7 @@ namespace GAME
 
 class CGameClientInput;
 class CGameClientKeyboard;
+class CGameClientMouse;
 class IGameAudioCallback;
 class IGameClientPlayback;
 class IGameVideoCallback;
@@ -126,6 +127,8 @@ private:
   bool SetRumble(unsigned int port, const std::string& feature, float magnitude);
   void OpenKeyboard(void);
   void CloseKeyboard(void);
+  void OpenMouse(void);
+  void CloseMouse(void);
   ControllerVector GetControllers(void) const;
 
   // Private memory stream functions
@@ -144,6 +147,7 @@ private:
   bool                  m_bSupportsVFS;
   bool                  m_bSupportsStandalone;
   bool                  m_bSupportsKeyboard;
+  bool                  m_bSupportsMouse;
   std::set<std::string> m_extensions;
   bool                  m_bSupportsAllExtensions;
   //GamePlatforms         m_platforms;
@@ -160,8 +164,9 @@ private:
   GAME_REGION           m_region;              // Region of the loaded game
 
   // Input
-  std::vector<CGameClientInput*> m_ports;
+  std::map<int, std::unique_ptr<CGameClientInput>> m_ports;
   std::unique_ptr<CGameClientKeyboard> m_keyboard;
+  std::unique_ptr<CGameClientMouse> m_mouse;
 
   CCriticalSection m_critSection;
 };

--- a/xbmc/games/addons/GameClientKeyboard.cpp
+++ b/xbmc/games/addons/GameClientKeyboard.cpp
@@ -56,11 +56,11 @@ bool CGameClientKeyboard::OnKeyPress(const CKey& key)
   game_input_event event;
 
   event.type            = GAME_INPUT_EVENT_KEY;
-  event.port            = -1;
+  event.port            = GAME_INPUT_PORT_KEYBOARD;
   event.controller_id   = ""; // TODO
   event.feature_name    = ""; // TODO
   event.key.pressed     = true;
-  event.key.character   = key.GetButtonCode() & BUTTON_INDEX_MASK;
+  event.key.character   = static_cast<XBMCVKey>(key.GetButtonCode() & BUTTON_INDEX_MASK);
   event.key.modifiers   = CGameClientTranslator::GetModifiers(static_cast<CKey::Modifier>(key.GetModifiers()));
 
   if (event.key.character != 0)
@@ -83,11 +83,11 @@ void CGameClientKeyboard::OnKeyRelease(const CKey& key)
   game_input_event event;
 
   event.type            = GAME_INPUT_EVENT_KEY;
-  event.port            = 0;
+  event.port            = GAME_INPUT_PORT_KEYBOARD;
   event.controller_id   = ""; // TODO
   event.feature_name    = ""; // TODO
   event.key.pressed     = false;
-  event.key.character   = key.GetButtonCode() & BUTTON_INDEX_MASK;
+  event.key.character   = static_cast<XBMCVKey>(key.GetButtonCode() & BUTTON_INDEX_MASK);
   event.key.modifiers   = CGameClientTranslator::GetModifiers(static_cast<CKey::Modifier>(key.GetModifiers()));
 
   if (event.key.character != 0)

--- a/xbmc/games/addons/GameClientMouse.cpp
+++ b/xbmc/games/addons/GameClientMouse.cpp
@@ -1,0 +1,127 @@
+/*
+ *      Copyright (C) 2015-2016 Team Kodi
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this Program; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "GameClientMouse.h"
+#include "GameClient.h"
+#include "GameClientTranslator.h"
+#include "addons/kodi-addon-dev-kit/include/kodi/kodi_game_types.h"
+#include "input/InputManager.h"
+#include "input/Key.h"
+#include "utils/log.h"
+
+using namespace GAME;
+
+CGameClientMouse::CGameClientMouse(const CGameClient* gameClient, const GameClient* dllStruct) :
+  m_gameClient(gameClient),
+  m_dllStruct(dllStruct),
+  m_controllerId(CInputManager::GetInstance().RegisterMouseHandler(this))
+{
+}
+
+CGameClientMouse::~CGameClientMouse()
+{
+  CInputManager::GetInstance().UnregisterMouseHandler(this);
+}
+
+std::string CGameClientMouse::ControllerID(void) const
+{
+  return m_controllerId;
+}
+
+bool CGameClientMouse::OnMotion(const std::string& relpointer, int dx, int dy)
+{
+  // Only allow activated input in fullscreen game
+  if (!m_gameClient->AcceptsInput())
+  {
+    return false;
+  }
+
+  bool bHandled = false;
+
+  game_input_event event;
+
+  event.type            = GAME_INPUT_EVENT_RELATIVE_POINTER;
+  event.port            = GAME_INPUT_PORT_MOUSE;
+  event.controller_id   = m_controllerId.c_str();
+  event.feature_name    = relpointer.c_str();
+  event.rel_pointer.x   = dx;
+  event.rel_pointer.y   = dy;
+
+  try
+  {
+    bHandled = m_dllStruct->InputEvent(&event);
+  }
+  catch (...)
+  {
+    CLog::Log(LOGERROR, "GAME: %s: exception caught in InputEvent()", m_gameClient->ID().c_str());
+  }
+
+  return bHandled;
+}
+
+bool CGameClientMouse::OnButtonPress(const std::string& button)
+{
+  // Only allow activated input in fullscreen game
+  if (!m_gameClient->AcceptsInput())
+  {
+    return false;
+  }
+
+  bool bHandled = false;
+
+  game_input_event event;
+
+  event.type                   = GAME_INPUT_EVENT_DIGITAL_BUTTON;
+  event.port                   = GAME_INPUT_PORT_MOUSE;
+  event.controller_id          = m_controllerId.c_str();
+  event.feature_name           = button.c_str();
+  event.digital_button.pressed = true;
+
+  try
+  {
+    bHandled = m_dllStruct->InputEvent(&event);
+  }
+  catch (...)
+  {
+    CLog::Log(LOGERROR, "GAME: %s: exception caught in InputEvent()", m_gameClient->ID().c_str());
+  }
+
+  return bHandled;
+}
+
+void CGameClientMouse::OnButtonRelease(const std::string& button)
+{
+  game_input_event event;
+
+  event.type                   = GAME_INPUT_EVENT_DIGITAL_BUTTON;
+  event.port                   = GAME_INPUT_PORT_MOUSE;
+  event.controller_id          = m_controllerId.c_str();
+  event.feature_name           = button.c_str();
+  event.digital_button.pressed = false;
+
+  try
+  {
+    m_dllStruct->InputEvent(&event);
+  }
+  catch (...)
+  {
+    CLog::Log(LOGERROR, "GAME: %s: exception caught in InputEvent()", m_gameClient->ID().c_str());
+  }
+}

--- a/xbmc/games/addons/GameClientMouse.h
+++ b/xbmc/games/addons/GameClientMouse.h
@@ -1,0 +1,48 @@
+/*
+ *      Copyright (C) 2015-2016 Team Kodi
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this Program; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+#pragma once
+
+#include "input/mouse/IMouseInputHandler.h"
+
+struct GameClient;
+
+namespace GAME
+{
+  class CGameClient;
+
+  class CGameClientMouse : public MOUSE::IMouseInputHandler
+  {
+  public:
+    CGameClientMouse(const CGameClient* gameClient, const GameClient* dllStruct);
+    ~CGameClientMouse();
+
+    // implementation of IMouseInputHandler
+    virtual std::string ControllerID(void) const override;
+    virtual bool OnMotion(const std::string& relpointer, int dx, int dy) override;
+    virtual bool OnButtonPress(const std::string& button) override;
+    virtual void OnButtonRelease(const std::string& button) override;
+
+  private:
+    // Construction parameters
+    const CGameClient* const m_gameClient;
+    const GameClient* const m_dllStruct;
+    const std::string m_controllerId;
+  };
+}

--- a/xbmc/games/controllers/ControllerDefinitions.h
+++ b/xbmc/games/controllers/ControllerDefinitions.h
@@ -27,6 +27,7 @@
 #define LAYOUT_XML_ELM_ANALOG_STICK        "analogstick"
 #define LAYOUT_XML_ELM_ACCELEROMETER       "accelerometer"
 #define LAYOUT_XML_ELM_MOTOR               "motor"
+#define LAYOUT_XML_ELM_RELPOINTER          "relpointer"
 
 #define LAYOUT_XML_ATTR_LAYOUT_LABEL       "label"
 #define LAYOUT_XML_ATTR_LAYOUT_IMAGE       "image"

--- a/xbmc/games/controllers/ControllerTranslator.cpp
+++ b/xbmc/games/controllers/ControllerTranslator.cpp
@@ -32,6 +32,7 @@ const char* CControllerTranslator::TranslateFeatureType(FEATURE_TYPE type)
     case FEATURE_TYPE::ANALOG_STICK:     return LAYOUT_XML_ELM_ANALOG_STICK;
     case FEATURE_TYPE::ACCELEROMETER:    return LAYOUT_XML_ELM_ACCELEROMETER;
     case FEATURE_TYPE::MOTOR:            return LAYOUT_XML_ELM_MOTOR;
+    case FEATURE_TYPE::RELPOINTER:       return LAYOUT_XML_ELM_RELPOINTER;
     default:
       break;
   }
@@ -44,6 +45,7 @@ FEATURE_TYPE CControllerTranslator::TranslateFeatureType(const std::string& strT
   if (strType == LAYOUT_XML_ELM_ANALOG_STICK)     return FEATURE_TYPE::ANALOG_STICK;
   if (strType == LAYOUT_XML_ELM_ACCELEROMETER)    return FEATURE_TYPE::ACCELEROMETER;
   if (strType == LAYOUT_XML_ELM_MOTOR)            return FEATURE_TYPE::MOTOR;
+  if (strType == LAYOUT_XML_ELM_RELPOINTER)       return FEATURE_TYPE::RELPOINTER;
 
   return FEATURE_TYPE::UNKNOWN;
 }

--- a/xbmc/games/controllers/windows/GUIConfigurationWizard.cpp
+++ b/xbmc/games/controllers/windows/GUIConfigurationWizard.cpp
@@ -223,6 +223,11 @@ bool CGUIConfigurationWizard::OnKeyPress(const CKey& key)
   return Abort(false);
 }
 
+bool CGUIConfigurationWizard::OnButtonPress(const std::string& button)
+{
+  return Abort(false);
+}
+
 void CGUIConfigurationWizard::InstallHooks(void)
 {
   using namespace PERIPHERALS;
@@ -233,11 +238,15 @@ void CGUIConfigurationWizard::InstallHooks(void)
   // If we're not using emulation, allow keyboard input to abort prompt
   if (!m_bEmulation)
     CInputManager::GetInstance().RegisterKeyboardHandler(this);
+
+  CInputManager::GetInstance().RegisterMouseHandler(this);
 }
 
 void CGUIConfigurationWizard::RemoveHooks(void)
 {
   using namespace PERIPHERALS;
+
+  CInputManager::GetInstance().UnregisterMouseHandler(this);
 
   if (!m_bEmulation)
     CInputManager::GetInstance().UnregisterKeyboardHandler(this);

--- a/xbmc/games/controllers/windows/GUIConfigurationWizard.h
+++ b/xbmc/games/controllers/windows/GUIConfigurationWizard.h
@@ -23,6 +23,7 @@
 #include "input/joysticks/DriverPrimitive.h"
 #include "input/joysticks/IButtonMapper.h"
 #include "input/keyboard/IKeyboardHandler.h"
+#include "input/mouse/IMouseInputHandler.h"
 #include "threads/CriticalSection.h"
 #include "threads/Event.h"
 #include "threads/Thread.h"
@@ -37,6 +38,7 @@ namespace GAME
   class CGUIConfigurationWizard : public IConfigurationWizard,
                                   public JOYSTICK::IButtonMapper,
                                   public KEYBOARD::IKeyboardHandler,
+                                  public MOUSE::IMouseInputHandler,
                                   public Observer,
                                   protected CThread
   {
@@ -60,6 +62,11 @@ namespace GAME
     // implementation of IKeyboardHandler
     virtual bool OnKeyPress(const CKey& key) override;
     virtual void OnKeyRelease(const CKey& key) override { }
+
+    // implementation of IMouseInputHandler
+    virtual bool OnMotion(const std::string& relpointer, int dx, int dy) override { return false; }
+    virtual bool OnButtonPress(const std::string& button) override;
+    virtual void OnButtonRelease(const std::string& button) override { }
 
     // implementation of Observer
     virtual void Notify(const Observable& obs, const ObservableMessage msg) override;

--- a/xbmc/input/InputManager.h
+++ b/xbmc/input/InputManager.h
@@ -44,6 +44,13 @@ namespace KEYBOARD
   class IKeyboardHandler;
 }
 
+namespace MOUSE
+{
+  class IMouseButtonMap;
+  class IMouseDriverHandler;
+  class IMouseInputHandler;
+}
+
 class CInputManager : public ISettingCallback
 {
 private:
@@ -223,6 +230,20 @@ public:
   void RegisterKeyboardHandler(KEYBOARD::IKeyboardHandler* handler);
   void UnregisterKeyboardHandler(KEYBOARD::IKeyboardHandler* handler);
 
+  /*! \brief Registers a handler to be called on mouse input (e.g a game client).
+   *
+   * \param handler The handler to call on mouse input.
+   * \return[in] The controller ID that serves as a context for incoming events.
+   * \sa IMouseButtonMap
+   */
+  std::string RegisterMouseHandler(MOUSE::IMouseInputHandler* handler);
+
+  /*! \brief Unregisters handler from mouse input.
+   *
+   * \param[in] handler The handler to unregister from mouse input.
+   */
+  void UnregisterMouseHandler(MOUSE::IMouseInputHandler* handler);
+
 private:
 
   /*! \brief Process keyboard event and translate into an action
@@ -274,6 +295,9 @@ private:
   CCriticalSection     m_actionMutex;
 
   std::vector<KEYBOARD::IKeyboardHandler*> m_keyboardHandlers;
+  typedef std::pair<MOUSE::IMouseInputHandler*, std::unique_ptr<MOUSE::IMouseDriverHandler>> MouseHandlerHandle;
+  std::vector<MouseHandlerHandle> m_mouseHandlers;
+  std::unique_ptr<MOUSE::IMouseButtonMap> m_mouseButtonMap;
 
   std::unique_ptr<KEYBOARD::IKeyboardHandler> m_keyboardEasterEgg;
 };

--- a/xbmc/input/joysticks/JoystickTypes.h
+++ b/xbmc/input/joysticks/JoystickTypes.h
@@ -37,6 +37,7 @@ namespace JOYSTICK
    *   2) analog stick
    *   3) accelerometer
    *   4) rumble motor
+   *   5) relative pointer
    *
    * [1] All three driver primitives (buttons, hats and axes) have a state that
    *     can be represented using a single scalar value. For this reason,
@@ -49,6 +50,7 @@ namespace JOYSTICK
     ANALOG_STICK,
     ACCELEROMETER,
     MOTOR,
+    RELPOINTER,
   };
 
   /*!

--- a/xbmc/input/mouse/CMakeLists.txt
+++ b/xbmc/input/mouse/CMakeLists.txt
@@ -1,0 +1,8 @@
+set(SOURCES MouseWindowingButtonMap.cpp)
+
+set(HEADERS IMouseButtonMap.h
+            IMouseDriverHandler.h
+            IMouseInputHandler.h
+            MouseWindowingButtonMap.h)
+
+core_add_library(input_mouse)

--- a/xbmc/input/mouse/IMouseButtonMap.h
+++ b/xbmc/input/mouse/IMouseButtonMap.h
@@ -1,0 +1,74 @@
+/*
+ *      Copyright (C) 2016 Team Kodi
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this Program; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+#pragma once
+
+#include <string>
+
+namespace MOUSE
+{
+  /*!
+   * \brief Button map interface to translate between the mouse's driver data
+   *        and its higher-level features.
+   */
+  class IMouseButtonMap
+  {
+  public:
+    virtual ~IMouseButtonMap(void) = default;
+
+    /*!
+     * \brief The ID of the controller profile associated with this button map
+     *
+     * The controller ID provided by the implementation serves as the context
+     * for the feature names below.
+     *
+     * \return The ID of this button map's controller profile
+     */
+    virtual std::string ControllerID(void) const = 0;
+
+    /*!
+     * \brief Get the name of a button by its index
+     *
+     * \param      buttonIndex   The index of the button
+     * \param[out] feature       The name of the feature with the specified button index
+     *
+     * \return True if the button index is associated with a feature, false otherwise
+     */
+    virtual bool GetButton(unsigned int buttonIndex, std::string& feature) = 0;
+
+    /*!
+     * \brief Get the name of the mouse's relative pointer
+     *
+     * \param[out] feature       The name of the relative pointer
+     *
+     * \return True if the mouse has a relative pointer, false otherwise
+     */
+    virtual bool GetRelativePointer(std::string& feature) = 0;
+
+    /*!
+     * \brief Get the button index for a button
+     *
+     * \param feature        The name of the button
+     * \param buttonIndex    The resolved button index
+     *
+     * \return True if the feature resolved to a button index, or false otherwise
+     */
+    virtual bool GetButtonIndex(const std::string& feature, unsigned int& buttonIndex) = 0;
+  };
+}

--- a/xbmc/input/mouse/IMouseDriverHandler.h
+++ b/xbmc/input/mouse/IMouseDriverHandler.h
@@ -1,0 +1,59 @@
+/*
+ *      Copyright (C) 2016 Team Kodi
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this Program; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+#pragma once
+
+namespace MOUSE
+{
+  /*!
+   * \ingroup input
+   * \brief Interface for handling mouse driver events
+   */
+  class IMouseDriverHandler
+  {
+  public:
+    virtual ~IMouseDriverHandler(void) = default;
+
+    /*!
+     * \brief Handle mouse position updates
+     *
+     * \param x  The new x coordinate of the pointer
+     * \param y  The new y coordinate of the pointer
+     *
+     * \return True if the event was handled, false otherwise
+     */
+    virtual bool OnPosition(int x, int y) = 0;
+
+    /*!
+     * \brief A mouse button has been pressed
+     *
+     * \param button   The index of the pressed button
+     *
+     * \return True if the event was handled, otherwise false
+     */
+    virtual bool OnButtonPress(unsigned int button) = 0;
+
+    /*!
+     * \brief A mouse button has been released
+     *
+     * \param button   The index of the released button
+     */
+    virtual void OnButtonRelease(unsigned int button) = 0;
+  };
+}

--- a/xbmc/input/mouse/IMouseInputHandler.h
+++ b/xbmc/input/mouse/IMouseInputHandler.h
@@ -1,0 +1,69 @@
+/*
+ *      Copyright (C) 2016 Team Kodi
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this Program; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+#pragma once
+
+#include <string>
+
+namespace MOUSE
+{
+  /*!
+   * \ingroup input
+   * \brief Interface for handling mouse events
+   */
+  class IMouseInputHandler
+  {
+  public:
+    virtual ~IMouseInputHandler(void) = default;
+
+    /*!
+     * \brief The controller profile for this mouse input handler
+     *
+     * \return The ID of the add-on extending kodi.game.controller
+     */
+    virtual std::string ControllerID(void) const = 0;
+
+    /*!
+     * \brief A relative pointer has moved
+     *
+     * \param relpointer   The name of the relative pointer being moved
+     * \param dx           The relative x coordinate of motion
+     * \param dy           The relative y coordinate of motion
+     *
+     * \return True if the event was handled, otherwise false
+     */
+    virtual bool OnMotion(const std::string& relpointer, int dx, int dy) = 0;
+
+    /*!
+     * \brief A mouse button has been pressed
+     *
+     * \param button      The name of the feature being pressed
+     *
+     * \return True if the event was handled, otherwise false
+     */
+    virtual bool OnButtonPress(const std::string& button) = 0;
+
+    /*!
+     * \brief A mouse button has been released
+     *
+     * \param button      The name of the feature being released
+     */
+    virtual void OnButtonRelease(const std::string& button) = 0;
+  };
+}

--- a/xbmc/input/mouse/Makefile
+++ b/xbmc/input/mouse/Makefile
@@ -1,0 +1,6 @@
+SRCS=MouseWindowingButtonMap.cpp \
+
+LIB=input_mouse.a
+
+include ../../../Makefile.include
+-include $(patsubst %.cpp,%.P,$(patsubst %.c,%.P,$(SRCS)))

--- a/xbmc/input/mouse/MouseWindowingButtonMap.cpp
+++ b/xbmc/input/mouse/MouseWindowingButtonMap.cpp
@@ -1,0 +1,83 @@
+/*
+ *      Copyright (C) 2016 Team Kodi
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this Program; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "MouseWindowingButtonMap.h"
+#include "input/MouseStat.h"
+
+#include <algorithm>
+
+using namespace MOUSE;
+
+#define CONTROLLER_PROFILE  "game.controller.mouse"
+
+std::vector<std::pair<unsigned int, std::string>> CMouseWindowingButtonMap::m_buttonMap = {
+  { XBMC_BUTTON_LEFT,      "left" },
+  { XBMC_BUTTON_MIDDLE,    "middle" },
+  { XBMC_BUTTON_RIGHT,     "right" },
+  { XBMC_BUTTON_WHEELUP,   "wheelup" },
+  { XBMC_BUTTON_WHEELDOWN, "wheeldown" },
+};
+
+std::string CMouseWindowingButtonMap::m_pointerName = "pointer";
+
+std::string CMouseWindowingButtonMap::ControllerID(void) const
+{
+  return CONTROLLER_PROFILE;
+}
+
+bool CMouseWindowingButtonMap::GetButton(unsigned int buttonIndex, std::string& feature)
+{
+  auto it = std::find_if(m_buttonMap.begin(), m_buttonMap.end(),
+    [buttonIndex](const std::pair<unsigned int, std::string>& entry)
+    {
+      return entry.first == buttonIndex;
+    });
+
+  if (it != m_buttonMap.end())
+  {
+    feature = it->second;
+    return true;
+  }
+
+  return false;
+}
+
+bool CMouseWindowingButtonMap::GetRelativePointer(std::string& feature)
+{
+  feature = m_pointerName;
+  return true;
+}
+
+bool CMouseWindowingButtonMap::GetButtonIndex(const std::string& feature, unsigned int& buttonIndex)
+{
+  auto it = std::find_if(m_buttonMap.begin(), m_buttonMap.end(),
+    [&feature](const std::pair<unsigned int, std::string>& entry)
+    {
+      return entry.second == feature;
+    });
+
+  if (it != m_buttonMap.end())
+  {
+    buttonIndex = it->first;
+    return true;
+  }
+  
+  return false;
+}

--- a/xbmc/input/mouse/MouseWindowingButtonMap.h
+++ b/xbmc/input/mouse/MouseWindowingButtonMap.h
@@ -1,0 +1,45 @@
+/*
+ *      Copyright (C) 2016 Team Kodi
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this Program; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+#pragma once
+
+#include "input/mouse/IMouseButtonMap.h"
+
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace MOUSE
+{
+  class CMouseWindowingButtonMap : public IMouseButtonMap
+  {
+  public:
+    virtual ~CMouseWindowingButtonMap(void) = default;
+
+    // implementation of IMouseButtonMap
+    virtual std::string ControllerID(void) const override;
+    virtual bool GetButton(unsigned int buttonIndex, std::string& feature) override;
+    virtual bool GetRelativePointer(std::string& feature) override;
+    virtual bool GetButtonIndex(const std::string& feature, unsigned int& buttonIndex) override;
+
+  private:
+    static std::vector<std::pair<unsigned int, std::string>> m_buttonMap;
+    static std::string m_pointerName;
+  };
+}

--- a/xbmc/input/mouse/generic/CMakeLists.txt
+++ b/xbmc/input/mouse/generic/CMakeLists.txt
@@ -1,0 +1,5 @@
+set(SOURCES MouseInputHandling.cpp)
+
+set(HEADERS MouseInputHandling.h)
+
+core_add_library(input_mouse_generic)

--- a/xbmc/input/mouse/generic/Makefile
+++ b/xbmc/input/mouse/generic/Makefile
@@ -1,0 +1,6 @@
+SRCS=MouseInputHandling.cpp \
+
+LIB=input_mouse_generic.a
+
+include ../../../../Makefile.include
+-include $(patsubst %.cpp,%.P,$(patsubst %.c,%.P,$(SRCS)))

--- a/xbmc/input/mouse/generic/MouseInputHandling.cpp
+++ b/xbmc/input/mouse/generic/MouseInputHandling.cpp
@@ -1,0 +1,68 @@
+/*
+ *      Copyright (C) 2016 Team Kodi
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this Program; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "MouseInputHandling.h"
+#include "input/mouse/IMouseButtonMap.h"
+#include "input/mouse/IMouseInputHandler.h"
+
+using namespace MOUSE;
+
+CMouseInputHandling::CMouseInputHandling(IMouseInputHandler* handler, IMouseButtonMap* buttonMap) :
+  m_handler(handler),
+  m_buttonMap(buttonMap),
+  m_x(0),
+  m_y(0)
+{
+}
+
+bool CMouseInputHandling::OnPosition(int x, int y)
+{
+  int dx = x - m_x;
+  int dy = y - m_y;
+
+  bool bHandled = false;
+
+  std::string featureName;
+  if (m_buttonMap->GetRelativePointer(featureName))
+    bHandled = m_handler->OnMotion(featureName, dx, dy);
+
+  m_x = x;
+  m_y = y;
+
+  return bHandled;
+}
+
+bool CMouseInputHandling::OnButtonPress(unsigned int button)
+{
+  bool bHandled = false;
+
+  std::string featureName;
+  if (m_buttonMap->GetButton(button, featureName))
+    bHandled = m_handler->OnButtonPress(featureName);
+
+  return bHandled;
+}
+
+void CMouseInputHandling::OnButtonRelease(unsigned int button)
+{
+  std::string featureName;
+  if (m_buttonMap->GetButton(button, featureName))
+    m_handler->OnButtonRelease(featureName);
+}

--- a/xbmc/input/mouse/generic/MouseInputHandling.h
+++ b/xbmc/input/mouse/generic/MouseInputHandling.h
@@ -1,0 +1,54 @@
+/*
+ *      Copyright (C) 2016 Team Kodi
+ *      http://kodi.tv
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this Program; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+#pragma once
+
+#include "input/mouse/IMouseDriverHandler.h"
+
+namespace MOUSE
+{
+  class IMouseInputHandler;
+  class IMouseButtonMap;
+  class CRelativePointer;
+
+  /*!
+   * \brief Class to translate input from driver info to higher-level features
+   */
+  class CMouseInputHandling : public IMouseDriverHandler
+  {
+  public:
+    CMouseInputHandling(IMouseInputHandler* handler, IMouseButtonMap* buttonMap);
+
+    virtual ~CMouseInputHandling(void) = default;
+
+    // implementation of IMouseDriverHandler
+    virtual bool OnPosition(int x, int y) override;
+    virtual bool OnButtonPress(unsigned int button) override;
+    virtual void OnButtonRelease(unsigned int button) override;
+
+  private:
+    // Construction parameters
+    IMouseInputHandler* const m_handler;
+    IMouseButtonMap* const    m_buttonMap;
+
+    // Mouse parameters
+    int m_x;
+    int m_y;
+  };
+}


### PR DESCRIPTION
Adds mouse support for Emulators like ScummVM or Dosbox. Fixes #6

Related changes:
- kodi: [PR](https://github.com/garbear/xbmc/pull/67) - [retroplayer-mouse](https://github.com/fetzerch/xbmc/tree/retroplayer-mouse)
- game.libretro: [PR](https://github.com/kodi-game/game.libretro/pull/7) - [mouse](https://github.com/fetzerch/game.libretro/tree/mouse)
- kodi-game-controllers: [PR](https://github.com/kodi-game/kodi-game-controllers/pull/5) - [mouse](https://github.com/kodi-game/kodi-game-controllers/tree/mouse)
- game.libretro.scummvm: [PR](https://github.com/kodi-game/game.libretro.scummvm/pull/6) - [mouse](https://github.com/fetzerch/game.libretro.scummvm/tree/mouse)
- game.libretro.dosbox: [PR](https://github.com/kodi-game/game.libretro.dosbox/pull/2) - [mouse](https://github.com/fetzerch/game.libretro.dosbox/tree/mouse)

Known issues:
- [x] Enable Joystick & Mouse at the same time (fixed by 4b3117e)
- [x] Dosbox crashes ([fixed array of 0-15 ports](https://github.com/libretro/dosbox-libretro/blob/master/libretro/libretro.cpp#L239), we call it with -2 (`GAME_INPUT_PORT_MOUSE`)) (fixed by https://github.com/kodi-game/game.libretro/pull/7/commits/c62477c34cd005cdc00c275e81888f06a03eeead)
- [ ] Mouse button mapping doen't work (clicks are ignored in mapping dialog)
