### PR TITLE
Windows renderer: Nearest neighbor video scaling

### DIFF
--- a/system/shaders/yuv2rgb_d3d.fx
+++ b/system/shaders/yuv2rgb_d3d.fx
@@ -30,7 +30,11 @@ SamplerState YUVSampler : IMMUTABLE
 {
   AddressU = CLAMP;
   AddressV = CLAMP;
+#ifdef SAMP_NEAREST
+  Filter   = MIN_MAG_MIP_POINT;
+#else
   Filter   = MIN_MAG_MIP_LINEAR;
+#endif
 };
 #ifdef NV12_SNORM_UV
 SamplerState UVSamplerSNORM : IMMUTABLE

--- a/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/WinVideoFilter.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/WinVideoFilter.cpp
@@ -248,6 +248,14 @@ bool CWinShader::Execute(const std::vector<CD3DTexture*> &targets, unsigned int 
   return true;
 }
 
+const std::vector<float>& CWinShader::GetColorRange(bool isLimitedRange)
+{
+  static const std::vector<float> fullRange{ 0.f, 1.f };
+  static const std::vector<float> limitedRange{ 16.f / 255.f, (235.f - 16.f) / 255.f };
+
+  return isLimitedRange ? limitedRange : fullRange;
+}
+
 //==================================================================================
 
 COutputShader::~COutputShader()
@@ -869,12 +877,8 @@ void CConvolutionShader1Pass::SetShaderParameters(CD3DTexture &sourceTexture, fl
   D3D11_VIEWPORT viewPort = {};
   g_Windowing.Get3D11Context()->RSGetViewports(&numVP, &viewPort);
   m_effect.SetFloatArray("g_viewPort", &viewPort.Width, 2);
-  float colorRange[2] =
-  {
-    (useLimitRange ?  16.f / 255.f : 0.f),
-    (useLimitRange ? 219.f / 255.f : 1.f),
-  };
-  m_effect.SetFloatArray("g_colorRange", colorRange, _countof(colorRange));
+  auto &range = GetColorRange(useLimitRange);
+  m_effect.SetFloatArray("g_colorRange", range.data(), range.size());
   if (m_pOutShader)
     m_pOutShader->ApplyEffectParameters(m_effect, sourceTexture.GetWidth(), sourceTexture.GetHeight());
 }
@@ -1116,12 +1120,8 @@ void CConvolutionShaderSeparable::SetShaderParameters(CD3DTexture &sourceTexture
   m_effect.SetTexture( "g_Texture",  sourceTexture );
   m_effect.SetTexture( "g_KernelTexture", m_HQKernelTexture );
   m_effect.SetFloatArray("g_StepXY", texSteps, texStepsCount);
-  float colorRange[2] =
-  {
-    (useLimitRange ?  16.f / 255.f : 0.f),
-    (useLimitRange ? 219.f / 255.f : 1.f)
-  };
-  m_effect.SetFloatArray("g_colorRange", colorRange, _countof(colorRange));
+  auto &range = GetColorRange(useLimitRange);
+  m_effect.SetFloatArray("g_colorRange", range.data(), range.size());
   if (m_pOutShader)
     m_pOutShader->ApplyEffectParameters(m_effect, sourceTexture.GetWidth(), sourceTexture.GetHeight());
 }

--- a/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/WinVideoFilter.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/WinVideoFilter.cpp
@@ -270,9 +270,9 @@ void COutputShader::ApplyEffectParameters(CD3DEffect &effect, unsigned sourceWid
   }
   if (m_useDithering)
   {
-    float ditherParams[3] = 
-    { 
-      static_cast<float>(sourceWidth) / dither_size, 
+    float ditherParams[3] =
+    {
+      static_cast<float>(sourceWidth) / dither_size,
       static_cast<float>(sourceHeight) / dither_size,
       static_cast<float>(1 << m_ditherDepth) - 1.0f
     };
@@ -588,7 +588,7 @@ void CYUV2RGBShader::PrepareParameters(CRenderBuffer* videoBuffer, CRect sourceR
                                        float contrast, float brightness)
 {
   if (m_sourceRect != sourceRect
-    || m_dest[0] != dest[0] || m_dest[1] != dest[1] 
+    || m_dest[0] != dest[0] || m_dest[1] != dest[1]
     || m_dest[2] != dest[2] || m_dest[3] != dest[3]
     || videoBuffer->GetWidth() != m_sourceWidth
     || videoBuffer->GetHeight() != m_sourceHeight)
@@ -808,7 +808,7 @@ bool CConvolutionShader1Pass::Create(ESCALINGMETHOD method, COutputShader *pCLUT
 void CConvolutionShader1Pass::Render(CD3DTexture &sourceTexture,
                                      unsigned int sourceWidth, unsigned int sourceHeight,
                                      unsigned int destWidth, unsigned int destHeight,
-                                     CRect sourceRect, CRect destRect, bool useLimitRange, 
+                                     CRect sourceRect, CRect destRect, bool useLimitRange,
                                      CD3DTexture *target)
 {
   PrepareParameters(sourceWidth, sourceHeight, sourceRect, destRect);
@@ -963,11 +963,11 @@ void CConvolutionShaderSeparable::Render(CD3DTexture &sourceTexture,
     CreateIntermediateRenderTarget(destWidth, sourceHeight);
 
   PrepareParameters(sourceWidth, sourceHeight, destWidth, destHeight, sourceRect, destRect);
-  float texSteps[] = 
-  { 
-    1.0f / static_cast<float>(sourceWidth), 
-    1.0f / static_cast<float>(sourceHeight), 
-    1.0f / static_cast<float>(destWidth), 
+  float texSteps[] =
+  {
+    1.0f / static_cast<float>(sourceWidth),
+    1.0f / static_cast<float>(sourceHeight),
+    1.0f / static_cast<float>(destWidth),
     1.0f / static_cast<float>(sourceHeight)
   };
   SetShaderParameters(sourceTexture, texSteps, 4, useLimitRange);
@@ -1055,7 +1055,7 @@ void CConvolutionShaderSeparable::PrepareParameters(unsigned int sourceWidth, un
     // Horizontal dimension: crop/zoom, so that it is completely done with the convolution shader. Scaling to display width in pass1 and
     // cropping/zooming in pass 2 would use bilinear in pass2, which we don't want.
     // Vertical dimension: crop using sourceRect to save memory bandwidth for high zoom values, but don't stretch/shrink in any way in this pass.
-    
+
     v[0].x = 0;
     v[0].y = 0;
     v[0].z = 0;
@@ -1116,8 +1116,8 @@ void CConvolutionShaderSeparable::SetShaderParameters(CD3DTexture &sourceTexture
   m_effect.SetTexture( "g_Texture",  sourceTexture );
   m_effect.SetTexture( "g_KernelTexture", m_HQKernelTexture );
   m_effect.SetFloatArray("g_StepXY", texSteps, texStepsCount);
-  float colorRange[2] = 
-  { 
+  float colorRange[2] =
+  {
     (useLimitRange ?  16.f / 255.f : 0.f),
     (useLimitRange ? 219.f / 255.f : 1.f)
   };
@@ -1131,7 +1131,7 @@ void CConvolutionShaderSeparable::SetStepParams(UINT iPass)
   ID3D11DeviceContext* pContext = g_Windowing.Get3D11Context();
 
   CD3D11_VIEWPORT viewPort = CD3D11_VIEWPORT(
-    0.0f, 
+    0.0f,
     0.0f,
     static_cast<float>(m_target->GetWidth()),
     static_cast<float>(m_target->GetHeight()));

--- a/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/WinVideoFilter.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/WinVideoFilter.h
@@ -48,6 +48,7 @@ private:
   bool         m_limitedRange;
   EBufferFormat m_format;
   XMFLOAT4X4   m_mat;
+  ESCALINGMETHOD m_scalingMethod;
 };
 
 class CWinShader
@@ -107,7 +108,7 @@ private:
   unsigned m_sourceWidth{ 0 };
   unsigned m_sourceHeight{ 0 };
   CRect m_sourceRect{ 0.f, 0.f, 0.f, 0.f };
-  CPoint m_destPoints[4] = 
+  CPoint m_destPoints[4] =
   {
     { 0.f, 0.f },
     { 0.f, 0.f },
@@ -131,13 +132,14 @@ class CYUV2RGBShader : public CWinShader
 public:
   CYUV2RGBShader();
   virtual ~CYUV2RGBShader();
-  virtual bool Create(EBufferFormat fmt, COutputShader *pOutShader = nullptr);
-  virtual void Render(CRect sourceRect, CPoint dest[], float contrast, float brightness, CRenderBuffer* videoBuffer, CD3DTexture *target);
+  virtual bool Create(EBufferFormat fmt, COutputShader *pOutShader = nullptr, ESCALINGMETHOD scalingMethod = VS_SCALINGMETHOD_LINEAR);
+  virtual void Render(CRect sourceRect, CPoint dest[], float contrast, float brightness, CRenderBuffer* videoBuffer, CD3DTexture *target, ESCALINGMETHOD scalingMethod = VS_SCALINGMETHOD_LINEAR);
 
 protected:
   void PrepareParameters(CRenderBuffer* videoBuffer, CRect sourceRect, CPoint dest[],
                          float contrast, float brightness);
   void SetShaderParameters(CRenderBuffer* videoBuffer);
+  void HandleScalerChange(ESCALINGMETHOD escalingMethod);
 
 private:
   CYUV2RGBMatrix      m_matrix;
@@ -147,6 +149,7 @@ private:
   EBufferFormat       m_format;
   float               m_texSteps[2];
   COutputShader *m_pOutShader;
+  ESCALINGMETHOD m_scalingMethod;
 
   struct CUSTOMVERTEX {
       FLOAT x, y, z;
@@ -191,14 +194,14 @@ public:
   void Render(CD3DTexture &sourceTexture,
               unsigned int sourceWidth, unsigned int sourceHeight,
               unsigned int destWidth, unsigned int destHeight,
-              CRect sourceRect, CRect destRect, bool useLimitRange, 
+              CRect sourceRect, CRect destRect, bool useLimitRange,
               CD3DTexture *target) override;
   CConvolutionShader1Pass() : CConvolutionShader(), m_sourceWidth(0), m_sourceHeight(0) {}
 
 protected:
   void PrepareParameters(unsigned int sourceWidth, unsigned int sourceHeight,
                          CRect sourceRect, CRect destRect);
-  void SetShaderParameters(CD3DTexture &sourceTexture, float* texSteps, 
+  void SetShaderParameters(CD3DTexture &sourceTexture, float* texSteps,
                            int texStepsCount, bool useLimitRange) override;
 
 
@@ -226,7 +229,7 @@ protected:
   void PrepareParameters(unsigned int sourceWidth, unsigned int sourceHeight,
                          unsigned int destWidth, unsigned int destHeight,
                          CRect sourceRect, CRect destRect);
-  void SetShaderParameters(CD3DTexture &sourceTexture, float* texSteps, 
+  void SetShaderParameters(CD3DTexture &sourceTexture, float* texSteps,
                            int texStepsCount, bool useLimitRange) override;
   void SetStepParams(UINT stepIndex) override;
 

--- a/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/WinVideoFilter.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/WinVideoFilter.h
@@ -67,6 +67,8 @@ protected:
   virtual void SetStepParams(UINT stepIndex) { }
   virtual bool CreateInputLayout(D3D11_INPUT_ELEMENT_DESC *layout, unsigned numElements);
 
+  static const std::vector<float>& GetColorRange(bool isLimitedRange);
+
   CD3DEffect   m_effect;
   CD3DTexture* m_target{ nullptr };
 

--- a/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/WinVideoFilter.h
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/VideoShaders/WinVideoFilter.h
@@ -160,11 +160,11 @@ public:
   virtual void Render(CD3DTexture &sourceTexture,
                       unsigned int sourceWidth, unsigned int sourceHeight,
                       unsigned int destWidth, unsigned int destHeight,
-                      CRect sourceRect, CRect destRect, bool useLimitRange, 
+                      CRect sourceRect, CRect destRect, bool useLimitRange,
                       CD3DTexture *target) = 0;
   CConvolutionShader();
   virtual ~CConvolutionShader();
-  
+
 protected:
   virtual bool ChooseKernelD3DFormat();
   virtual bool CreateHQKernel(ESCALINGMETHOD method);

--- a/xbmc/cores/VideoPlayer/VideoRenderers/WinRenderer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/WinRenderer.cpp
@@ -39,13 +39,13 @@
 #include "VideoShaders/WinVideoFilter.h"
 #include "windowing/WindowingFactory.h"
 
-typedef struct 
+typedef struct
 {
   RenderMethod  method;
   const char   *name;
 } RenderMethodDetail;
 
-static RenderMethodDetail RenderMethodDetails[] = 
+static RenderMethodDetail RenderMethodDetails[] =
 {
     { RENDER_SW     , "Software" },
     { RENDER_PS     , "Pixel Shaders" },
@@ -290,7 +290,7 @@ void CWinRenderer::Reset()
 
 void CWinRenderer::Update()
 {
-  if (!m_bConfigured) 
+  if (!m_bConfigured)
     return;
   ManageRenderArea();
   ManageTextures();
@@ -343,7 +343,7 @@ void CWinRenderer::UnInit()
 
   SAFE_DELETE(m_colorShader);
   SAFE_DELETE(m_scalerShader);
-  
+
   m_bConfigured = false;
   m_bFilterInitialized = false;
 
@@ -467,7 +467,7 @@ EBufferFormat CWinRenderer::SelectBufferFormat(AVPixelFormat format, const Rende
     case DXGI_FORMAT_P016:
       decoderFormat = AV_PIX_FMT_YUV420P16;
       break;
-    default: 
+    default:
       break;
     }
   }
@@ -557,7 +557,7 @@ void CWinRenderer::SelectPSVideoFilter()
   if (m_scalingMethod == VS_SCALINGMETHOD_AUTO)
   {
     bool scaleSD = m_sourceHeight < 720 && m_sourceWidth < 1280;
-    bool scaleUp = static_cast<int>(m_sourceHeight) < g_graphicsContext.GetHeight() 
+    bool scaleUp = static_cast<int>(m_sourceHeight) < g_graphicsContext.GetHeight()
                 && static_cast<int>(m_sourceWidth) < g_graphicsContext.GetWidth();
     bool scaleFps = m_fps < (g_advancedSettings.m_videoAutoScaleMaxFps + 0.01f);
 
@@ -741,7 +741,7 @@ void CWinRenderer::RenderSW(CD3DTexture* target)
     return;
 
   // Don't know where this martian comes from but it can happen in the initial frames of a video
-  if (m_destRect.x1 < 0 && m_destRect.x2 < 0 
+  if (m_destRect.x1 < 0 && m_destRect.x2 < 0
    || m_destRect.y1 < 0 && m_destRect.y2 < 0)
     return;
 
@@ -778,7 +778,7 @@ void CWinRenderer::RenderSW(CD3DTexture* target)
 
   for (unsigned int idx = 0; idx < buf->GetActivePlanes(); idx++)
     buf->MapPlane(idx, reinterpret_cast<void**>(&src[idx]), &srcStride[idx]);
-  
+
   D3D11_MAPPED_SUBRESOURCE destlr;
   if (!m_IntermediateTarget.LockRect(0, &destlr, D3D11_MAP_WRITE_DISCARD))
     CLog::Log(LOGERROR, "%s: failed to lock swtarget texture into memory.", __FUNCTION__);
@@ -814,7 +814,7 @@ void CWinRenderer::RenderPS(CD3DTexture* target)
   // reset view port
   g_Windowing.Get3D11Context()->RSSetViewports(1, &viewPort);
 
-  // select destination rectangle 
+  // select destination rectangle
   CPoint destPoints[4];
   if (m_renderOrientation)
   {
@@ -854,7 +854,7 @@ void CWinRenderer::RenderHW(DWORD flags, CD3DTexture* target)
     && image->format != BUFFER_FMT_D3D11_P010
     && image->format != BUFFER_FMT_D3D11_P016)
     return;
-  
+
   if (!image->HasPic())
     return;
 
@@ -920,7 +920,7 @@ void CWinRenderer::RenderHW(DWORD flags, CD3DTexture* target)
 
   CRect src = m_sourceRect, dst = destRect;
   CRect targetRect = CRect(0.0f, 0.0f,
-                       static_cast<float>(m_IntermediateTarget.GetWidth()), 
+                       static_cast<float>(m_IntermediateTarget.GetWidth()),
                        static_cast<float>(m_IntermediateTarget.GetHeight()));
 
   if (target != g_Windowing.GetBackBuffer())
@@ -1030,7 +1030,7 @@ bool CWinRenderer::Supports(ESCALINGMETHOD method)
   {
     if (m_renderMethod == RENDER_DXVA)
     {
-      if (method == VS_SCALINGMETHOD_DXVA_HARDWARE 
+      if (method == VS_SCALINGMETHOD_DXVA_HARDWARE
        || method == VS_SCALINGMETHOD_AUTO)
         return true;
       if (!g_advancedSettings.m_DXVAAllowHqScaling || m_renderOrientation)
@@ -1038,7 +1038,7 @@ bool CWinRenderer::Supports(ESCALINGMETHOD method)
     }
 
     if ( method == VS_SCALINGMETHOD_AUTO
-     || (method == VS_SCALINGMETHOD_LINEAR && m_renderMethod == RENDER_PS)) 
+     || (method == VS_SCALINGMETHOD_LINEAR && m_renderMethod == RENDER_PS))
         return true;
 
     if (g_Windowing.GetFeatureLevel() >= D3D_FEATURE_LEVEL_9_3 && !m_renderOrientation)
@@ -1103,15 +1103,15 @@ bool CWinRenderer::HandlesVideoBuffer(CVideoBuffer* buffer)
 CRenderInfo CWinRenderer::GetRenderInfo()
 {
   CRenderInfo info;
-  info.formats = 
-  { 
-    AV_PIX_FMT_D3D11VA_VLD, 
-    AV_PIX_FMT_NV12, 
-    AV_PIX_FMT_P010, 
-    AV_PIX_FMT_P016, 
-    AV_PIX_FMT_YUV420P, 
-    AV_PIX_FMT_YUV420P10, 
-    AV_PIX_FMT_YUV420P16 
+  info.formats =
+  {
+    AV_PIX_FMT_D3D11VA_VLD,
+    AV_PIX_FMT_NV12,
+    AV_PIX_FMT_P010,
+    AV_PIX_FMT_P016,
+    AV_PIX_FMT_YUV420P,
+    AV_PIX_FMT_YUV420P10,
+    AV_PIX_FMT_YUV420P16
   };
   info.max_buffer_size = NUM_BUFFERS;
   if (m_renderMethod == RENDER_DXVA && m_processor)

--- a/xbmc/cores/VideoPlayer/VideoRenderers/WinRenderer.cpp
+++ b/xbmc/cores/VideoPlayer/VideoRenderers/WinRenderer.cpp
@@ -623,7 +623,7 @@ void CWinRenderer::UpdatePSVideoFilter()
   }
 
   m_colorShader = new CYUV2RGBShader();
-  if (!m_colorShader->Create(m_bufferFormat, m_bUseHQScaler ? nullptr : m_outputShader.get()))
+  if (!m_colorShader->Create(m_bufferFormat, m_bUseHQScaler ? nullptr : m_outputShader.get(), m_scalingMethod))
   {
     if (m_bUseHQScaler)
     {
@@ -834,7 +834,7 @@ void CWinRenderer::RenderPS(CD3DTexture* target)
   m_colorShader->Render(m_sourceRect, destPoints,
                         CMediaSettings::GetInstance().GetCurrentVideoSettings().m_Contrast,
                         CMediaSettings::GetInstance().GetCurrentVideoSettings().m_Brightness,
-                        &m_renderBuffers[m_iYV12RenderBuffer], target);
+                        &m_renderBuffers[m_iYV12RenderBuffer], target, m_scalingMethod);
   // Restore our view port.
   g_Windowing.RestoreViewPort();
 }
@@ -1035,6 +1035,11 @@ bool CWinRenderer::Supports(ESCALINGMETHOD method)
         return true;
       if (!g_advancedSettings.m_DXVAAllowHqScaling || m_renderOrientation)
         return false;
+    }
+    else // RENDER_PS
+    {
+      if (method == VS_SCALINGMETHOD_NEAREST)
+        return true;
     }
 
     if ( method == VS_SCALINGMETHOD_AUTO


### PR DESCRIPTION
This PR implements nearest neighbor video filtering/scaling for the Pixel Shader renderer used on Windows.

## Description
<!--- Describe your change in detail -->
Nearest neighbor scaling is the conventional scaling used in emulators for older systems, as it results in the most accurate and crisp image. The lack of it was the first thing I noticed when I initially tried RetroPlayer, so I decided to take a crack at it.

It's implemented on Linux, but for windows it was only implemented in the software renderer. DXVA and the Pixel Shader renderer didn't support it. This PR implements it for the Pixel Shader renderer.
It's not needed for DXVA (would be pretty hacky anyway; it doesn't seem to allow you to change the scaling), since we'll probably ditch it for RetroPlayer.

For a few implementation details, here's a copy of the main commit message:

* I tried to change as few things as possible by using the
color shader used in the pixel renderer to do the sampling.
* It's all compile-time and the shader gets recompiled when
it needs to (if the sampling option changed from/to nearest
neigbor, to/from something else).

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->
For RetroPlayer, this was without a doubt needed eventually.
Low res games were really ugly/smudgy with the default filtering. With nearest neighbor the image looks as crisp as it should.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your change -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc -->
Tested in RetroPlayer by loading a Game Boy emulator and a game. The difference is quite obvious :)

## Screenshots (if appropriate):
Before: 
![image](https://user-images.githubusercontent.com/6632271/28500500-0ce60398-6fd2-11e7-9453-c97b1ffed3ab.png)

After: 
![image](https://user-images.githubusercontent.com/6632271/28500502-1046330a-6fd2-11e7-9c73-9d5ccd6a46b4.png)

(more obvious full-screen)


## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [Code guidelines](https://codedocs.xyz/xbmc/xbmc/code_guidelines.html) of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [x] I have read the [CONTRIBUTING](https://github.com/xbmc/xbmc/blob/master/CONTRIBUTING.md) document
- [ ] I have added tests to cover my change
- [ ] All new and existing tests passed
