### PR TITLE
[RetroPlayer] Add basic resolution changing

### DIFF
--- a/xbmc/cores/RetroPlayer/rendering/RPRenderManager.cpp
+++ b/xbmc/cores/RetroPlayer/rendering/RPRenderManager.cpp
@@ -100,20 +100,32 @@ bool CRPRenderManager::Configure(AVPixelFormat format, unsigned int nominalWidth
 
   CSingleLock lock(m_stateMutex);
 
-  m_state = RENDER_STATE::CONFIGURING;
+  if (m_state == RENDER_STATE::UNCONFIGURED)
+    m_state = RENDER_STATE::CONFIGURING;
+  else
+  {
+    Flush();
+    m_state = RENDER_STATE::RECONFIGURING;
+  }
 
   return true;
 }
 
 void CRPRenderManager::AddFrame(const uint8_t* data, size_t size, unsigned int width, unsigned int height, unsigned int orientationDegCCW)
 {
+  if (m_bFlush || m_state != RENDER_STATE::CONFIGURED)
+    return;
+
   // Validate parameters
   if (data == nullptr || size == 0 || width == 0 || height == 0)
     return;
 
-  //! @todo Allow dimension changes
   if (width != m_width || height != m_height)
+  {
+    // Reconfigure
+    Configure(m_format, width, height, m_maxWidth, m_maxHeight);
     return;
+  }
 
   // Copy frame to buffers with visible renderers
   std::vector<IRenderBuffer*> renderBuffers;
@@ -128,6 +140,8 @@ void CRPRenderManager::AddFrame(const uint8_t* data, size_t size, unsigned int w
       CopyFrame(renderBuffer, m_format, data, size, width, height);
       renderBuffers.emplace_back(renderBuffer);
     }
+    else
+      CLog::Log(LOGDEBUG, "RetroPlayer[RENDER]: Unable to get render buffer for frame");
   }
 
   {
@@ -171,7 +185,7 @@ void CRPRenderManager::SetSpeed(double speed)
 
 void CRPRenderManager::FrameMove()
 {
-  UpdateResolution();
+  CheckFlush();
 
   bool bIsConfigured = false;
 
@@ -183,9 +197,20 @@ void CRPRenderManager::FrameMove()
       m_processInfo.ConfigureRenderSystem(m_format);
 
       MESSAGING::CApplicationMessenger::GetInstance().PostMsg(TMSG_SWITCHTOFULLSCREEN);
+
       m_state = RENDER_STATE::CONFIGURED;
 
       CLog::Log(LOGINFO, "RetroPlayer[RENDER]: Renderer configured on first frame");
+    }
+    else if (m_state == RENDER_STATE::RECONFIGURING)
+    {
+      CLog::Log(LOGDEBUG, "RetroPlayer[RENDER]: Reconfiguring %u renderer(s)", m_renderers.size());
+
+      // Reconfigure any existing renderers
+      for (auto &renderer : m_renderers)
+        renderer->Configure(m_format, m_width, m_height);
+
+      m_state = RENDER_STATE::CONFIGURED;
     }
 
     if (m_state == RENDER_STATE::CONFIGURED)
@@ -199,9 +224,34 @@ void CRPRenderManager::FrameMove()
   }
 }
 
+void CRPRenderManager::CheckFlush()
+{
+  if (m_bFlush)
+  {
+    {
+      CSingleLock lock(m_bufferMutex);
+      for (auto renderBuffer : m_renderBuffers)
+        renderBuffer->Release();
+      m_renderBuffers.clear();
+
+      m_cachedFrame.clear();
+
+      m_bHasCachedFrame = false;
+    }
+
+    for (const auto &renderer : m_renderers)
+      renderer->Flush();
+
+    m_processInfo.GetBufferManager().FlushPools();
+
+
+    m_bFlush = false;
+  }
+}
+
 void CRPRenderManager::Flush()
 {
-  m_processInfo.GetBufferManager().FlushPools();
+  m_bFlush = true;
 }
 
 void CRPRenderManager::TriggerUpdateResolution()
@@ -372,7 +422,10 @@ std::shared_ptr<CRPBaseRenderer> CRPRenderManager::GetRenderer(IRenderBufferPool
   std::shared_ptr<CRPBaseRenderer> renderer;
 
   if (!bufferPool->IsCompatible(renderSettings.VideoSettings()))
+  {
+    CLog::Log(LOGERROR, "RetroPlayer[RENDER]: buffer pool is not compatible with renderer");
     return renderer;
+  }
 
   // Get compatible renderer for this buffer pool
   for (const auto &it : m_renderers)
@@ -436,6 +489,9 @@ bool CRPRenderManager::HasRenderBuffer(IRenderBufferPool *bufferPool)
 
 IRenderBuffer *CRPRenderManager::GetRenderBuffer(IRenderBufferPool *bufferPool)
 {
+  if (m_bFlush || m_state != RENDER_STATE::CONFIGURED)
+    return nullptr;
+
   IRenderBuffer *renderBuffer = nullptr;
 
   CSingleLock lock(m_bufferMutex);
@@ -457,6 +513,9 @@ IRenderBuffer *CRPRenderManager::GetRenderBuffer(IRenderBufferPool *bufferPool)
 
 void CRPRenderManager::CreateRenderBuffer(IRenderBufferPool *bufferPool)
 {
+  if (m_bFlush || m_state != RENDER_STATE::CONFIGURED)
+    return;
+
   CSingleLock lock(m_bufferMutex);
 
   if (!HasRenderBuffer(bufferPool) && m_bHasCachedFrame)

--- a/xbmc/cores/RetroPlayer/rendering/RPRenderManager.cpp
+++ b/xbmc/cores/RetroPlayer/rendering/RPRenderManager.cpp
@@ -49,7 +49,6 @@ using namespace RETRO;
 CRPRenderManager::CRPRenderManager(CRPProcessInfo &processInfo) :
   m_processInfo(processInfo),
   m_renderContext(processInfo.GetRenderContext()),
-  m_speed(1.0),
   m_renderSettings(new CGUIGameSettings(processInfo)),
   m_renderControlFactory(new CGUIRenderTargetFactory(this))
 {
@@ -157,8 +156,16 @@ void CRPRenderManager::AddFrame(const uint8_t* data, size_t size, unsigned int w
     {
       std::vector<uint8_t> cachedFrame = std::move(m_cachedFrame);
 
-      if (!m_bHasCachedFrame)
+      if (m_bHasCachedFrame)
       {
+        // In this case, cachedFrame may be empty if the frame is being
+        // copied in the rendering thread. We want to leave cached frame
+        // empty to avoid caching another frame.
+      }
+      else
+      {
+        // In this case, cachedFrame is definitely empty (see invariant for
+        // m_bHasCachedFrame)
         cachedFrame.resize(size);
         m_bHasCachedFrame = true;
       }
@@ -520,27 +527,39 @@ void CRPRenderManager::CreateRenderBuffer(IRenderBufferPool *bufferPool)
 
   if (!HasRenderBuffer(bufferPool) && m_bHasCachedFrame)
   {
-    std::vector<uint8_t> cachedFrame = std::move(m_cachedFrame);
-    if (!cachedFrame.empty())
-    {
-      CLog::Log(LOGERROR, "RetroPlayer[RENDER]: Creating render buffer for renderer");
-
-      IRenderBuffer *renderBuffer = bufferPool->GetBuffer(cachedFrame.size());
-      if (renderBuffer != nullptr)
-      {
-        {
-          CSingleExit exit(m_bufferMutex);
-          CopyFrame(renderBuffer, m_format, cachedFrame.data(), cachedFrame.size(), m_width, m_height);
-        }
-        m_renderBuffers.emplace_back(renderBuffer);
-      }
-      m_cachedFrame = std::move(cachedFrame);
-    }
-    else
-    {
-      CLog::Log(LOGERROR, "RetroPlayer[RENDER]: Failed to create render buffer, no cached frame");
-    }
+    IRenderBuffer *renderBuffer = CreateFromCache(m_cachedFrame, bufferPool, m_bufferMutex);
+    if (renderBuffer != nullptr)
+      m_renderBuffers.emplace_back(renderBuffer);
   }
+}
+
+IRenderBuffer *CRPRenderManager::CreateFromCache(std::vector<uint8_t> &cachedFrame, IRenderBufferPool *bufferPool, CCriticalSection &mutex)
+{
+  // Take ownership of cached frame
+  std::vector<uint8_t> ownedFrame = std::move(cachedFrame);
+
+  if (!ownedFrame.empty())
+  {
+    CLog::Log(LOGERROR, "RetroPlayer[RENDER]: Creating render buffer for renderer");
+
+    IRenderBuffer *renderBuffer = bufferPool->GetBuffer(ownedFrame.size());
+    if (renderBuffer != nullptr)
+    {
+      CSingleExit exit(mutex);
+      CopyFrame(renderBuffer, m_format, ownedFrame.data(), ownedFrame.size(), m_width, m_height);
+    }
+
+    // Return ownership of cached frame
+    cachedFrame = std::move(ownedFrame);
+
+    return renderBuffer;
+  }
+  else
+  {
+    CLog::Log(LOGERROR, "RetroPlayer[RENDER]: Failed to create render buffer, no cached frame");
+  }
+
+  return nullptr;
 }
 
 void CRPRenderManager::UpdateResolution()

--- a/xbmc/cores/RetroPlayer/rendering/RPRenderManager.h
+++ b/xbmc/cores/RetroPlayer/rendering/RPRenderManager.h
@@ -146,6 +146,8 @@ namespace RETRO
 
     CRenderVideoSettings GetEffectiveSettings(const IGUIRenderSettings *settings) const;
 
+    void CheckFlush();
+
     // Construction parameters
     CRPProcessInfo &m_processInfo;
     CRenderContext &m_renderContext;
@@ -162,6 +164,7 @@ namespace RETRO
     {
       UNCONFIGURED,
       CONFIGURING,
+      RECONFIGURING,
       CONFIGURED,
     };
     RENDER_STATE m_state = RENDER_STATE::UNCONFIGURED;
@@ -175,6 +178,7 @@ namespace RETRO
     bool m_bHasCachedFrame = false;
     std::set<std::string> m_failedShaderPresets;
     bool m_bTriggerUpdateResolution = false;
+    std::atomic<bool> m_bFlush = {false};
     CCriticalSection m_stateMutex;
     CCriticalSection m_bufferMutex;
   };

--- a/xbmc/cores/RetroPlayer/rendering/RPRenderManager.h
+++ b/xbmc/cores/RetroPlayer/rendering/RPRenderManager.h
@@ -67,7 +67,7 @@ namespace RETRO
    *
    * Special behavior is needed when the game is paused. As no new frames are
    * delivered, a newly created renderer will stay black. For this scenario,
-   * when we detect a pause event, the frame is premptively cached so that a
+   * when we detect a pause event, the frame is preemptively cached so that a
    * newly created renderer will have something to display.
    */
   class CRPRenderManager : public IRenderManager,
@@ -137,6 +137,29 @@ namespace RETRO
      */
     void CreateRenderBuffer(IRenderBufferPool *bufferPool);
 
+    /*!
+     * \brief Create a render buffer and copy the cached data into it
+     *
+     * The cached frame is accessed by both the game and rendering threads,
+     * and therefore requires synchronization.
+     *
+     * However, assuming the memory copy is expensive, we must avoid holding
+     * the mutex during the copy.
+     *
+     * To allow for this, the function is permitted to invalidate its
+     * cachedFrame parameter, as long as it is restored upon exit. While the
+     * mutex is exited inside this function, cachedFrame is guaranteed to be
+     * empty.
+     *
+     * \param cachedFrame The cached frame
+     * \param bufferPool The buffer pool used to create the render buffer
+     * \param mutex The locked mutex, to be unlocked during memory copy
+     *
+     * \return The render buffer if one was created from the cached frame,
+     *         otherwise nullptr
+     */
+    IRenderBuffer *CreateFromCache(std::vector<uint8_t> &cachedFrame, IRenderBufferPool *bufferPool, CCriticalSection &mutex);
+
     void UpdateResolution();
 
     /*!
@@ -152,6 +175,10 @@ namespace RETRO
     CRPProcessInfo &m_processInfo;
     CRenderContext &m_renderContext;
 
+    // Subsystems
+    std::shared_ptr<IGUIRenderSettings> m_renderSettings;
+    std::shared_ptr<CGUIRenderTargetFactory> m_renderControlFactory;
+
     // Stream properties
     AVPixelFormat m_format = AV_PIX_FMT_NONE;
     unsigned int m_maxWidth = 0;
@@ -159,7 +186,13 @@ namespace RETRO
     unsigned int m_width = 0; //! @todo Remove me when dimension changing is implemented
     unsigned int m_height = 0; //! @todo Remove me when dimension changing is implemented
 
-    // Render properties
+    // Render resources
+    std::set<std::shared_ptr<CRPBaseRenderer>> m_renderers;
+    std::vector<IRenderBuffer*> m_renderBuffers;
+    std::map<AVPixelFormat, SwsContext*> m_scalers;
+    std::vector<uint8_t> m_cachedFrame;
+
+    // State parameters
     enum class RENDER_STATE
     {
       UNCONFIGURED,
@@ -168,17 +201,15 @@ namespace RETRO
       CONFIGURED,
     };
     RENDER_STATE m_state = RENDER_STATE::UNCONFIGURED;
-    std::atomic<double> m_speed;
-    std::shared_ptr<IGUIRenderSettings> m_renderSettings;
-    std::set<std::shared_ptr<CRPBaseRenderer>> m_renderers;
-    std::shared_ptr<CGUIRenderTargetFactory> m_renderControlFactory;
-    std::vector<IRenderBuffer*> m_renderBuffers;
-    std::vector<uint8_t> m_cachedFrame;
-    std::map<AVPixelFormat, SwsContext*> m_scalers;
-    bool m_bHasCachedFrame = false;
+    bool m_bHasCachedFrame = false; // Invariant: m_cachedFrame is empty if false
     std::set<std::string> m_failedShaderPresets;
     bool m_bTriggerUpdateResolution = false;
     std::atomic<bool> m_bFlush = {false};
+
+    // Playback parameters
+    std::atomic<double> m_speed = {1.0};
+
+    // Synchronization parameters
     CCriticalSection m_stateMutex;
     CCriticalSection m_bufferMutex;
   };


### PR DESCRIPTION
<!--- Provide a general summary of your change in the Title above -->

## Description
Add basic resolution changing.

## Motivation and Context
RetroPlayer does not render after resolution change.

## How Has This Been Tested?
PCSX, GenesisPlus, Nestopia. Example: FFVII on PCSX changes resolution every time the in-game menu is accessed.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [x] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
