### PR TITLE
[RetroPlayer] Flush/sync audio

### DIFF
--- a/xbmc/cores/RetroPlayer/streams/RetroPlayerAudio.cpp
+++ b/xbmc/cores/RetroPlayer/streams/RetroPlayerAudio.cpp
@@ -85,11 +85,15 @@ bool CRetroPlayerAudio::OpenStream(const StreamProperties& properties)
   if (m_pAudioStream != nullptr)
     CloseStream();
 
-  CLog::Log(LOGINFO, "RetroPlayer[AUDIO]: Creating audio stream, sample rate = %d", iSampleRate);
 
   IAE* audioEngine = CServiceBroker::GetActiveAE();
   if (audioEngine == nullptr)
     return false;
+
+  CLog::Log(LOGINFO, "RetroPlayer[AUDIO]: Creating audio stream, format = %s, sample rate = %d, channels = %d",
+             CAEUtil::DataFormatToStr(pcmFormat)
+             , iSampleRate
+             , channelLayout.Count());
 
   AEAudioFormat audioFormat;
   audioFormat.m_dataFormat = pcmFormat;
@@ -118,8 +122,19 @@ void CRetroPlayerAudio::AddStreamData(const StreamPacket &packet)
   {
     if (m_pAudioStream)
     {
+      const double delay = m_pAudioStream->GetDelay();
+
       const size_t frameSize = m_pAudioStream->GetChannelCount() * (CAEUtil::DataFormatToBits(m_pAudioStream->GetDataFormat()) >> 3);
-      m_pAudioStream->AddData(&audioPacket.data, 0, static_cast<unsigned int>(audioPacket.size / frameSize));
+
+      const unsigned int frameCount = static_cast<unsigned int>(audioPacket.size / frameSize);
+
+      if (delay > 0.3)
+      {
+        m_pAudioStream->Flush();
+        CLog::Log(LOGDEBUG, "RetroPlayer[AUDIO]: Audio delay (%0.2f ms) is too high - flushing", delay * 1000);
+      }
+
+      m_pAudioStream->AddData(&audioPacket.data, 0, frameCount);
     }
   }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your change in the Title above -->

## Description
Requires PR #99 . Flush audio (re-sync) if delay is too high.

## Motivation and Context
Over-buffering of audio causes significant delay.

## How Has This Been Tested?
PCSX

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
