### PR TITLE
[RetroPlayer] Reset Amlogic on render de-init

### DIFF
--- a/xbmc/cores/RetroPlayer/rendering/RPRenderManager.cpp
+++ b/xbmc/cores/RetroPlayer/rendering/RPRenderManager.cpp
@@ -64,6 +64,9 @@ void CRPRenderManager::Deinitialize()
 {
   CLog::Log(LOGDEBUG, "RetroPlayer[RENDER]: Deinitializing render manager");
 
+  // Required to reset Amlogic chip to default state
+  m_processInfo.ConfigureRenderSystem(AV_PIX_FMT_NONE);
+
   for (auto &pixelScaler : m_scalers)
   {
     if (pixelScaler.second != nullptr)


### PR DESCRIPTION
<!--- Provide a general summary of your change in the Title above -->

## Description
The Amlogic chip must be reset to default state. See 5a71afd

## How Has This Been Tested?
Odroid-C2

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Improvement (non-breaking change which improves existing functionality)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)