### PR TITLE
Retroplayer - savastate database DeleteSavestate method

### DIFF
--- a/xbmc/cores/RetroPlayer/savestates/SavestateDatabase.cpp
+++ b/xbmc/cores/RetroPlayer/savestates/SavestateDatabase.cpp
@@ -107,10 +107,15 @@ bool CSavestateDatabase::RenameSavestate(const std::string& path, const std::str
   return false;
 }
 
-bool CSavestateDatabase::DeleteSavestate(const std::string& path)
+bool CSavestateDatabase::DeleteSavestate(const std::string& gamePath)
 {
-  //! @todo
-  return false;
+  const std::string savestatePath = CSavestateUtils::MakePath(gamePath);
+  if (!XFILE::CFile::Delete(savestatePath))
+  {
+    CLog::Log(LOGERROR, "Failed to delete savestate file %s", CURL::GetRedacted(savestatePath).c_str());
+    return false;
+  }
+  return true;
 }
 
 bool CSavestateDatabase::ClearSavestatesOfGame(const std::string& gamePath, const std::string& gameClient /* = "" */)

--- a/xbmc/cores/RetroPlayer/savestates/SavestateDatabase.h
+++ b/xbmc/cores/RetroPlayer/savestates/SavestateDatabase.h
@@ -35,7 +35,7 @@ namespace RETRO
 
     bool RenameSavestate(const std::string& path, const std::string& label);
 
-    bool DeleteSavestate(const std::string& path);
+    bool DeleteSavestate(const std::string& gamePath);
 
     bool ClearSavestatesOfGame(const std::string& gamePath, const std::string& gameClient = "");
   };


### PR DESCRIPTION
## Description
Basic implementation of DeleteSavestate method.

## Motivation and Context
I am going to apply for the GSoC 2020 for the saved game manager and I found this method that I could write for a first PR. This implementation can be kept as is when the manager is created since the CSavestateUtils::MakePath will probably need a rewrite to return a path that is not next to the rom.

## How Has This Been Tested?

## Screenshots (if appropriate):

## Types of change
- [ ] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [X] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [ ] I have added tests to cover my change
- [X] All new and existing tests passed
