### PR TITLE
Replaced deviceName with Location

### DIFF
--- a/xbmc/games/controllers/dialogs/GUIDialogAxisDetection.cpp
+++ b/xbmc/games/controllers/dialogs/GUIDialogAxisDetection.cpp
@@ -44,7 +44,7 @@ bool CGUIDialogAxisDetection::MapPrimitiveInternal(JOYSTICK::IButtonMap* buttonM
                                                    const JOYSTICK::CDriverPrimitive& primitive)
 {
   if (primitive.Type() == JOYSTICK::PRIMITIVE_TYPE::SEMIAXIS)
-    AddAxis(buttonMap->DeviceName(), primitive.Index());
+    AddAxis(buttonMap->Location(), primitive.Index());
 
   return true;
 }
@@ -65,19 +65,19 @@ bool CGUIDialogAxisDetection::AcceptsPrimitive(JOYSTICK::PRIMITIVE_TYPE type) co
 void CGUIDialogAxisDetection::OnLateAxis(const JOYSTICK::IButtonMap* buttonMap,
                                          unsigned int axisIndex)
 {
-  AddAxis(buttonMap->DeviceName(), axisIndex);
+  AddAxis(buttonMap->Location(), axisIndex);
 }
 
-void CGUIDialogAxisDetection::AddAxis(const std::string& deviceName, unsigned int axisIndex)
+void CGUIDialogAxisDetection::AddAxis(const std::string& deviceLocation, unsigned int axisIndex)
 {
   auto it = std::find_if(m_detectedAxes.begin(), m_detectedAxes.end(),
-                         [&deviceName, axisIndex](const AxisEntry& axis) {
-                           return axis.first == deviceName && axis.second == axisIndex;
+                         [&deviceLocation, axisIndex](const AxisEntry& axis) {
+                           return axis.first == deviceLocation && axis.second == axisIndex;
                          });
 
   if (it == m_detectedAxes.end())
   {
-    m_detectedAxes.emplace_back(std::make_pair(deviceName, axisIndex));
+    m_detectedAxes.emplace_back(std::make_pair(deviceLocation, axisIndex));
     m_captureEvent.Set();
   }
 }

--- a/xbmc/games/controllers/dialogs/GUIDialogAxisDetection.h
+++ b/xbmc/games/controllers/dialogs/GUIDialogAxisDetection.h
@@ -41,7 +41,7 @@ protected:
   }
 
 private:
-  void AddAxis(const std::string& deviceName, unsigned int axisIndex);
+  void AddAxis(const std::string& deviceLocation, unsigned int axisIndex);
 
   // Axis types
   using DeviceName = std::string;

--- a/xbmc/games/controllers/dialogs/GUIDialogIgnoreInput.cpp
+++ b/xbmc/games/controllers/dialogs/GUIDialogIgnoreInput.cpp
@@ -61,21 +61,21 @@ bool CGUIDialogIgnoreInput::MapPrimitiveInternal(JOYSTICK::IButtonMap* buttonMap
                                                  const JOYSTICK::CDriverPrimitive& primitive)
 {
   // Check if we have already started capturing primitives for a device
-  const bool bHasDevice = !m_deviceName.empty();
+  const bool bHasDevice = !m_location.empty();
 
   // If a primitive comes from a different device, ignore it
-  if (bHasDevice && m_deviceName != buttonMap->DeviceName())
+  if (bHasDevice && m_location != buttonMap->Location())
   {
     CLog::Log(LOGDEBUG, "%s: ignoring input from device %s", buttonMap->ControllerID().c_str(),
-              buttonMap->DeviceName().c_str());
+              buttonMap->Location().c_str());
     return false;
   }
 
   if (!bHasDevice)
   {
     CLog::Log(LOGDEBUG, "%s: capturing input for device %s", buttonMap->ControllerID().c_str(),
-              buttonMap->DeviceName().c_str());
-    m_deviceName = buttonMap->DeviceName();
+              buttonMap->Location().c_str());
+    m_location = buttonMap->Location();
   }
 
   if (AddPrimitive(primitive))
@@ -95,10 +95,10 @@ void CGUIDialogIgnoreInput::OnClose(bool bAccepted)
     {
       // See documentation of IButtonMapCallback::ResetIgnoredPrimitives()
       // for why this call is needed
-      if (m_deviceName.empty())
+      if (m_location.empty())
         callback.second->ResetIgnoredPrimitives();
 
-      if (m_deviceName.empty() || m_deviceName == callback.first)
+      if (m_location.empty() || m_location == callback.first)
         callback.second->SaveButtonMap();
     }
     else

--- a/xbmc/games/controllers/dialogs/GUIDialogIgnoreInput.h
+++ b/xbmc/games/controllers/dialogs/GUIDialogIgnoreInput.h
@@ -40,7 +40,7 @@ protected:
 private:
   bool AddPrimitive(const JOYSTICK::CDriverPrimitive& primitive);
 
-  std::string m_deviceName;
+  std::string m_location;
   std::vector<JOYSTICK::CDriverPrimitive> m_capturedPrimitives;
 };
 } // namespace GAME

--- a/xbmc/games/controllers/windows/GUIConfigurationWizard.cpp
+++ b/xbmc/games/controllers/windows/GUIConfigurationWizard.cpp
@@ -48,7 +48,7 @@ void CGUIConfigurationWizard::InitializeState(void)
   m_throttleDirection = JOYSTICK::THROTTLE_DIRECTION::NONE;
   m_history.clear();
   m_lateAxisDetected = false;
-  m_deviceName.clear();
+  m_location.clear();
 }
 
 void CGUIConfigurationWizard::Run(const std::string& strControllerId,
@@ -205,7 +205,7 @@ bool CGUIConfigurationWizard::MapPrimitive(JOYSTICK::IButtonMap* buttonMap,
   bool bHandled = false;
 
   // Abort if another controller cancels the prompt
-  if (IsMapping() && !IsMapping(buttonMap->DeviceName()))
+  if (IsMapping() && !IsMapping(buttonMap->Location()))
   {
     //! @todo This only succeeds for game.controller.default; no actions are
     //        currently defined for other controllers
@@ -282,8 +282,8 @@ bool CGUIConfigurationWizard::MapPrimitive(JOYSTICK::IButtonMap* buttonMap,
         }
         else
         {
-          CLog::Log(LOGDEBUG, "%s: mapping feature \"%s\" for device %s", m_strControllerId.c_str(),
-                    feature.Name().c_str(), buttonMap->DeviceName().c_str());
+          CLog::Log(LOGDEBUG, "%s: mapping feature \"%s\" for device at location %s", m_strControllerId.c_str(),
+                    feature.Name().c_str(), buttonMap->Location().c_str());
 
           switch (feature.Type())
           {
@@ -338,9 +338,9 @@ bool CGUIConfigurationWizard::MapPrimitive(JOYSTICK::IButtonMap* buttonMap,
 
           m_inputEvent.Set();
 
-          if (m_deviceName.empty())
+          if (m_location.empty())
           {
-            m_deviceName = buttonMap->DeviceName();
+            m_location = buttonMap->Location();
             m_bIsKeyboard = (primitive.Type() == PRIMITIVE_TYPE::KEY);
           }
         }
@@ -443,12 +443,12 @@ bool CGUIConfigurationWizard::OnAction(unsigned int actionId)
 
 bool CGUIConfigurationWizard::IsMapping() const
 {
-  return !m_deviceName.empty();
+  return !m_location.empty();
 }
 
-bool CGUIConfigurationWizard::IsMapping(const std::string& deviceName) const
+bool CGUIConfigurationWizard::IsMapping(const std::string& location) const
 {
-  return m_deviceName == deviceName;
+  return m_location == location;
 }
 
 void CGUIConfigurationWizard::InstallHooks(void)

--- a/xbmc/games/controllers/windows/GUIConfigurationWizard.h
+++ b/xbmc/games/controllers/windows/GUIConfigurationWizard.h
@@ -89,7 +89,7 @@ private:
   void InitializeState(void);
 
   bool IsMapping() const;
-  bool IsMapping(const std::string& deviceName) const;
+  bool IsMapping(const std::string& location) const;
 
   void InstallHooks(void);
   void RemoveHooks(void);
@@ -110,7 +110,7 @@ private:
   JOYSTICK::THROTTLE_DIRECTION m_throttleDirection;
   std::set<JOYSTICK::CDriverPrimitive> m_history; // History to avoid repeated features
   bool m_lateAxisDetected;    // Set to true if an axis is detected during button mapping
-  std::string m_deviceName;   // Name of device that we're mapping
+  std::string m_location;   // Peripheral Location of device that we're mapping
   bool m_bIsKeyboard = false; // True if we're mapping keyboard keys
   CCriticalSection m_stateMutex;
 

--- a/xbmc/input/joysticks/interfaces/IButtonMap.h
+++ b/xbmc/input/joysticks/interfaces/IButtonMap.h
@@ -41,11 +41,11 @@ public:
   virtual std::string ControllerID(void) const = 0;
 
   /*!
-   * \brief The name of the peripheral associated with this button map
+   * \brief The Location of the peripheral associated with this button map
    *
-   * \return The peripheral's name
+   * \return The peripheral's location
    */
-  virtual std::string DeviceName(void) const = 0;
+  virtual std::string Location(void) const = 0;
 
   /*!
    * \brief Load the button map into memory

--- a/xbmc/peripherals/addons/AddonButtonMap.cpp
+++ b/xbmc/peripherals/addons/AddonButtonMap.cpp
@@ -39,9 +39,9 @@ CAddonButtonMap::~CAddonButtonMap(void)
     addon->UnregisterButtonMap(this);
 }
 
-std::string CAddonButtonMap::DeviceName(void) const
+std::string CAddonButtonMap::Location(void) const
 {
-  return m_device->DeviceName();
+  return m_device->Location();
 }
 
 bool CAddonButtonMap::Load(void)
@@ -66,7 +66,7 @@ bool CAddonButtonMap::Load(void)
   if (bSuccess)
     driverMap = CreateLookupTable(features);
   else
-    CLog::Log(LOGDEBUG, "Failed to load button map for \"%s\"", m_device->DeviceName().c_str());
+    CLog::Log(LOGDEBUG, "Failed to load button map for device at location \"%s\"", m_device->Location().c_str());
 
   {
     CSingleLock lock(m_mutex);

--- a/xbmc/peripherals/addons/AddonButtonMap.h
+++ b/xbmc/peripherals/addons/AddonButtonMap.h
@@ -35,7 +35,7 @@ public:
     return m_strControllerId;
   }
 
-  std::string DeviceName(void) const override;
+  std::string Location(void) const override;
 
   bool Load(void) override;
 


### PR DESCRIPTION
## Description
Replaced the use of deviceName with that of location for `IButtonMap`
Replaces https://github.com/garbear/xbmc/pull/118#event-3489956838

## Motivation and Context
Earlier the configuration wizard blocked input while mapping based on the device name of peripherals. This means two peripherals with different names won't be able to interfere which each other's mapping process. but at the same time, two with the same name could be mapped to a singular virtual device. 
This was fixed using the peripheral location instead of the name.

## How Has This Been Tested?
Tested using two controllers of the same model and trying to configure both to the same virtual device at the same time.
Now only the peripheral which initiates the wizard will be mapped while the input from the other controller will be ignored.
The code was compiled without any issues as well.

## Screenshots (if appropriate):

## Types of change
<!--- What type of change does your code introduce? Put an `x` in all the boxes that apply like this: [X] -->
- [X] **Bug fix** (non-breaking change which fixes an issue)
- [ ] **Clean up** (non-breaking change which removes non-working, unmaintained functionality)
- [ ] **Improvement** (non-breaking change which improves existing functionality)
- [ ] **New feature** (non-breaking change which adds functionality)
- [ ] **Breaking change** (fix or feature that will cause existing functionality to change)
- [ ] **Cosmetic change** (non-breaking change that doesn't touch code)
- [ ] **None of the above** (please explain below)

## Checklist:
<!--- Go over all the following points, and put an `X` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the **[Code Guidelines](https://github.com/xbmc/xbmc/blob/master/docs/CODE_GUIDELINES.md)** of this project 
- [ ] My change requires a change to the documentation, either Doxygen or wiki
- [ ] I have updated the documentation accordingly
- [X] I have read the **[Contributing](https://github.com/xbmc/xbmc/blob/master/docs/CONTRIBUTING.md)** document
- [X] I have added tests to cover my change
- [X] All new and existing tests passed