### PR TITLE
fix sampler for nearest neighbor scaling

### DIFF
--- a/system/shaders/guishader_common.hlsl
+++ b/system/shaders/guishader_common.hlsl
@@ -42,13 +42,7 @@ SamplerState LinearSampler : register(s0)
   Comparison = NEVER;
 };
 
-SamplerState NearestSampler : register(s1)
-{
-  Filter = MIN_MAG_MIP_POINT;
-  AddressU = CLAMP;
-  AddressV = CLAMP;
-  Comparison = NEVER;
-};
+SamplerState NearestSampler : register(s1);
 
 cbuffer cbWorld : register(b0)
 {

--- a/xbmc/guilib/GUIShaderDX.h
+++ b/xbmc/guilib/GUIShaderDX.h
@@ -114,6 +114,7 @@ private:
   void Release(void);
   bool CreateBuffers(void);
   bool CreateSamplers(void);
+  void SetSamplers(void);
   void ApplyChanges(void);
   void ClipToScissorParams(void);
 
@@ -126,6 +127,7 @@ private:
   CD3DVertexShader m_vertexShader;
   CD3DPixelShader m_pixelShader[SHADER_METHOD_RENDER_COUNT];
   Microsoft::WRL::ComPtr<ID3D11SamplerState> m_pSampLinear;
+  Microsoft::WRL::ComPtr<ID3D11SamplerState> m_pSampNearestNeightbor;
 
   // GUI buffers
   bool m_bIsWVPDirty;


### PR DESCRIPTION
Fixes the setup of a sampler with point sampling. To be merged with the original commit 7242d4a2e333a2d65cb8acb67ed685f3fd6a4870

Initialization of m_pSampNearestNeightbor in constructor is not needed (not a base type), but it follows the pattern of the rest of the code.

## Screenshots (if appropriate):
![image](https://github.com/garbear/xbmc/assets/489377/2b8ce6b1-1173-4bdc-823b-bdb43c193bab)
