### PR TITLE
Keymaps improvements

### DIFF
--- a/system/keymaps/joystick.xml
+++ b/system/keymaps/joystick.xml
@@ -132,7 +132,6 @@
   </FullscreenVideo>
   <FullscreenGame>
     <joystick profile="game.controller.default">
-      <back>noop</back>
       <start holdtime="1000">OSD</start>
       <guide>OSD</guide>
       <!-- Give games access to volume controls -->
@@ -183,6 +182,11 @@
       -->
     </joystick>
   </FullscreenGame>
+  <GameOSD>
+    <joystick profile="game.controller.default">
+      <back>noop</back>
+    </joystick>
+  </GameOSD>
   <FullscreenLiveTV>
     <joystick profile="game.controller.default">
       <a>Pause</a>

--- a/system/keymaps/joystick.xml
+++ b/system/keymaps/joystick.xml
@@ -132,6 +132,7 @@
   </FullscreenVideo>
   <FullscreenGame>
     <joystick profile="game.controller.default">
+      <back>Noop</back>
       <start holdtime="1000">OSD</start>
       <guide>OSD</guide>
       <!-- Give games access to volume controls -->
@@ -168,8 +169,7 @@
       <!-- <a hotkey="back">Screenshot</a> -->
       <!-- Reset is disabled until player can undo a reset -->
       <!--<b hotkey="back">PlayerControl(Reset)</b> -->
-      <x hotkey="back">OSD</x>
-      <y hotkey="back">OSD</y>
+      <a hotkey="back">OSD</a>
       <start hotkey="back">Stop</start>
       <rightbumper hotkey="back">AnalogFastForward</rightbumper>
       <leftbumper hotkey="back">AnalogRewind</leftbumper>

--- a/system/keymaps/joystick.xml
+++ b/system/keymaps/joystick.xml
@@ -168,6 +168,7 @@
       <!-- <a hotkey="back">Screenshot</a> -->
       <!-- Reset is disabled until player can undo a reset -->
       <!--<b hotkey="back">PlayerControl(Reset)</b> -->
+      <y hotkey="back">OSD</y>
       <a hotkey="back">OSD</a>
       <start hotkey="back">Stop</start>
       <rightbumper hotkey="back">AnalogFastForward</rightbumper>

--- a/system/keymaps/joystick.xml
+++ b/system/keymaps/joystick.xml
@@ -132,7 +132,7 @@
   </FullscreenVideo>
   <FullscreenGame>
     <joystick profile="game.controller.default">
-      <back>Noop</back>
+      <back>noop</back>
       <start holdtime="1000">OSD</start>
       <guide>OSD</guide>
       <!-- Give games access to volume controls -->

--- a/system/keymaps/mouse.xml
+++ b/system/keymaps/mouse.xml
@@ -57,7 +57,7 @@
   </FullscreenVideo>
   <FullscreenGame>
     <mouse>
-      <rightclick>Info</rightclick>
+      <mousemove>noop</mousemove>
     </mouse>
   </FullscreenGame>
   <contextmenu>  <!-- Give a way out of the context menu without actually having to select something.  -->

--- a/system/keymaps/mouse.xml
+++ b/system/keymaps/mouse.xml
@@ -53,8 +53,19 @@
   <FullscreenVideo>
     <mouse>
       <rightclick>Info</rightclick>
+      <mousemove>noop</mousemove>
     </mouse>
   </FullscreenVideo>
+  <FullscreenLiveTV>
+    <mouse>
+      <mousemove>noop</mousemove>
+    </mouse>
+  </FullscreenLiveTV>
+  <Visualisation>
+    <mouse>
+      <mousemove>noop</mousemove>
+    </mouse>
+  </Visualisation>
   <FullscreenGame>
     <mouse>
       <mousemove>noop</mousemove>


### PR DESCRIPTION
Some very few but effective keymaps improvements which could go along especially well with the latest GameOSD UI updates. 


If i see correctly, as of today, on controllers, GameOSD can be opened (and closed) in at least 3 ways:

- Xbox/PS Button
- Select + X (Speaking in Xbox button namings; =left face button)
- Select + Y (Speaking in Xbox button namings; =top face button)
- Long hold "Start"

I changed "Select + X" and "Select + Y" to only "Select + A" because:

- Having too many ways to reach the same navigation goal is sometimes more confusing than helpful. Less can be more
- The change to "Select + A" came to mind because i found it ergonomically easier to access and also with the general idea in mind that in rare cases there might be a controller which only has 2 face buttons and therefore does not have a "X" or "Y" button for this combo.

Feel free to correct if i overlooked anything or something else comes to mind.

Cheers