### PR TITLE
Games: drive the asynchronous audio interface

### DIFF
--- a/xbmc/addons/kodi-dev-kit/include/kodi/addon-instance/Game.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/addon-instance/Game.h
@@ -388,6 +388,19 @@ public:
   /// @return The error, or @ref GAME_ERROR_NO_ERROR if there was no error
   ///
   virtual GAME_ERROR RunFrame() { return GAME_ERROR_NOT_IMPLEMENTED; }
+
+  //==========================================================================
+  /// @brief Tell the client the frontend is ready for audio
+  ///
+  /// Only implemented by clients that asked for the asynchronous audio
+  /// interface. Such a client produces no audio of its own accord: it waits to
+  /// be asked, then writes what it has through AddStreamData() on the thread
+  /// this was called from.
+  ///
+  /// @return The error, or GAME_ERROR_NO_ERROR if audio was handled
+  ///
+  virtual GAME_ERROR AudioAvailable() { return GAME_ERROR_NOT_IMPLEMENTED; }
+  //--------------------------------------------------------------------------
   //----------------------------------------------------------------------------
 
   //============================================================================
@@ -1238,6 +1251,7 @@ private:
     instance->game->toAddon->GetRegion = ADDON_GetRegion;
     instance->game->toAddon->RequiresGameLoop = ADDON_RequiresGameLoop;
     instance->game->toAddon->RunFrame = ADDON_RunFrame;
+    instance->game->toAddon->AudioAvailable = ADDON_AudioAvailable;
     instance->game->toAddon->Reset = ADDON_Reset;
 
     instance->game->toAddon->HwContextReset = ADDON_HwContextReset;
@@ -1338,6 +1352,11 @@ private:
   inline static bool ADDON_RequiresGameLoop(const AddonInstance_Game* instance)
   {
     return static_cast<CInstanceGame*>(instance->toAddon->addonInstance)->RequiresGameLoop();
+  }
+
+  inline static GAME_ERROR ADDON_AudioAvailable(const AddonInstance_Game* instance)
+  {
+    return static_cast<CInstanceGame*>(instance->toAddon->addonInstance)->AudioAvailable();
   }
 
   inline static GAME_ERROR ADDON_RunFrame(const AddonInstance_Game* instance)

--- a/xbmc/addons/kodi-dev-kit/include/kodi/c-api/addon-instance/game.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/c-api/addon-instance/game.h
@@ -1319,6 +1319,19 @@ extern "C"
     char*(__cdecl* GetImagePath)(const AddonInstance_Game*, unsigned int);
     char*(__cdecl* GetImageLabel)(const AddonInstance_Game*, unsigned int);
     void(__cdecl* FreeString)(const AddonInstance_Game*, char*);
+
+    /*!
+     * @brief Tell the client the frontend is ready for audio
+     *
+     * Only for clients that asked for the asynchronous audio interface. Such a
+     * client produces no audio of its own accord; it waits to be asked, and
+     * writes what it has through AddStreamData() on the thread this was called
+     * from. A client that is never asked stays silent, and on a frontend that
+     * paces itself on audio it also runs unthrottled.
+     *
+     * Clients using the ordinary synchronous audio path ignore this.
+     */
+    GAME_ERROR(__cdecl* AudioAvailable)(const AddonInstance_Game*);
   } KodiToAddonFuncTable_Game;
 
   /*!

--- a/xbmc/addons/kodi-dev-kit/include/kodi/versions.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/versions.h
@@ -97,8 +97,8 @@
 #define ADDON_INSTANCE_VERSION_AUDIOENCODER_DEPENDS   "c-api/addon-instance/audioencoder.h" \
                                                       "addon-instance/AudioEncoder.h"
 
-#define ADDON_INSTANCE_VERSION_GAME                   "6.0.0"
-#define ADDON_INSTANCE_VERSION_GAME_MIN               "6.0.0"
+#define ADDON_INSTANCE_VERSION_GAME                   "7.0.0"
+#define ADDON_INSTANCE_VERSION_GAME_MIN               "7.0.0"
 #define ADDON_INSTANCE_VERSION_GAME_XML_ID            "kodi.binary.instance.game"
 #define ADDON_INSTANCE_VERSION_GAME_DEPENDS           "addon-instance/Game.h"
 

--- a/xbmc/games/addons/GameClient.cpp
+++ b/xbmc/games/addons/GameClient.cpp
@@ -549,6 +549,17 @@ void CGameClient::RunFrame()
     try
     {
       LogError(m_ifc.game->toAddon->RunFrame(m_ifc.game), "RunFrame()");
+
+      // A client using the asynchronous audio interface produces no audio of
+      // its own accord: it waits to be asked, once per frame, and writes what
+      // it has from this thread. One that is never asked is silent, and since
+      // the frame rate is paced against the audio it delivers, it also runs as
+      // fast as the machine allows. Clients on the ordinary synchronous path
+      // answer this with GAME_ERROR_NOT_IMPLEMENTED and are unaffected.
+      const GAME_ERROR audioError = m_ifc.game->toAddon->AudioAvailable(m_ifc.game);
+      if (audioError != GAME_ERROR_NO_ERROR && audioError != GAME_ERROR_NOT_IMPLEMENTED)
+        LogError(audioError, "AudioAvailable()");
+
       m_hasFrameRun = true;
     }
     catch (...)


### PR DESCRIPTION
Kodi accepts a client's registration for the asynchronous audio interface and then never asks it for audio.

A client on that interface produces no audio of its own accord — it waits to be asked, and writes what it has from the thread it was asked on. Since nothing ever asks, it stays silent for the whole session.

Silence isn't the only symptom. The frame rate is paced against the audio a client delivers, so a client that is never asked also runs as fast as the machine allows rather than at the speed of the console. That's how I found it: a Dreamcast core running at roughly double speed, with no sound.

`game.libretro` has had the client half implemented for years, with a comment noting *"this function is not part of the Game API yet"*. This adds it to the API and calls it once per frame, alongside `RunFrame()`.

### Compatibility

Clients on the ordinary synchronous audio path inherit the default `AudioAvailable()`, which returns `GAME_ERROR_NOT_IMPLEMENTED`, and are unaffected — no source change needed in any existing add-on.

Adding an entry to `KodiToAddonFuncTable_Game` does change the layout of a struct shared with add-on binaries, so this bumps the game instance version to 7.0.0 and the minimum with it. Existing add-ons need a rebuild, not a code change. Happy to split the bump out or sequence it behind whatever else is queued for 7.0.0 if you'd rather batch the ABI breaks.

### Testing

Verified against Flycast via `game.libretro`, on the hardware-rendering branch: the client goes from silent to producing audio, and the pacing follows.

One caveat worth stating plainly — Flycast needed a separate `game.libretro` fix (answering `RETRO_ENVIRONMENT_GET_FASTFORWARDING`) before it produced any audio at all, so that core exercised both changes together. The reasoning here stands on its own: the interface is registered and then never driven.
