### PR TITLE
Games: make rumble reach the controller

### DIFF
--- a/xbmc/games/addons/input/GameClientJoystick.cpp
+++ b/xbmc/games/addons/input/GameClientJoystick.cpp
@@ -203,8 +203,36 @@ bool CGameClientJoystick::SetRumble(const std::string& feature, float magnitude)
 {
   bool bHandled = false;
 
-  if (InputReceiver())
-    bHandled = InputReceiver()->SetRumbleState(feature, magnitude);
+  // Ask the port, not this handler. CPortInput is what registers with the
+  // peripheral, so it is the one the peripheral attaches its receiver to; this
+  // class sits behind it and is never given one. Reading it here has meant that
+  // every motor event a game produced was dropped, for every core.
+  JOYSTICK::IInputReceiver* receiver = m_portInput ? m_portInput->InputReceiver() : nullptr;
+
+  if (receiver != nullptr)
+    bHandled = receiver->SetRumbleState(feature, magnitude);
+
+  // Report the first motor event, and the first that fails, once each. A game
+  // asking for rumble and not producing any is otherwise entirely silent: the
+  // request is well-formed the whole way down and simply stops, either because
+  // no receiver was attached to this handler or because the peripheral's button
+  // map has no motor of that name for the connected device.
+  if (!m_bLoggedRumble || (!bHandled && !m_bLoggedRumbleFailure))
+  {
+    if (bHandled)
+    {
+      CLog::Log(LOGDEBUG, "GAME: Rumble \"{}\" at {:0.2f} accepted by the peripheral", feature,
+                magnitude);
+      m_bLoggedRumble = true;
+    }
+    else
+    {
+      CLog::Log(LOGWARNING, "GAME: Rumble \"{}\" went nowhere ({})", feature,
+                receiver ? "the peripheral would not take it"
+                                : "no input receiver is attached to this handler");
+      m_bLoggedRumbleFailure = true;
+    }
+  }
 
   return bHandled;
 }

--- a/xbmc/games/addons/input/GameClientJoystick.h
+++ b/xbmc/games/addons/input/GameClientJoystick.h
@@ -98,6 +98,10 @@ private:
   // Input parameters
   std::unique_ptr<CPortInput> m_portInput;
   PERIPHERALS::PeripheralPtr m_sourcePeripheral;
+
+  // Motor events are reported once each, not once per frame of rumble
+  bool m_bLoggedRumble{false};
+  bool m_bLoggedRumbleFailure{false};
 };
 } // namespace GAME
 } // namespace KODI

--- a/xbmc/peripherals/addons/AddonButtonMap.cpp
+++ b/xbmc/peripherals/addons/AddonButtonMap.cpp
@@ -9,6 +9,9 @@
 #include "AddonButtonMap.h"
 
 #include "PeripheralAddonTranslator.h"
+#include "games/controllers/Controller.h"
+#include "games/controllers/ControllerManager.h"
+#include "games/controllers/input/PhysicalFeature.h"
 #include "input/joysticks/JoystickUtils.h"
 #include "peripherals/Peripherals.h"
 #include "peripherals/devices/Peripheral.h"
@@ -183,8 +186,55 @@ bool CAddonButtonMap::GetScalar(const FeatureName& feature, CDriverPrimitive& pr
       retVal = true;
     }
   }
+  else
+  {
+    // Nothing has mapped this feature. If the controller profile calls it a
+    // motor, map it here by position rather than leaving it unmapped.
+    //
+    // Motors cannot be mapped the way everything else is. The configuration
+    // wizard asks the user to activate each feature in turn, and a motor is
+    // not something that can be activated, so the wizard never offers one and
+    // no button map has ever contained a motor entry. The result is that a
+    // game asking for rumble finds nothing to drive, on every controller.
+    //
+    // Position is the only thing available to map by, and it is what the
+    // drivers use: the first motor a controller declares is the strong one,
+    // the second the weak one, matching the order evdev reports them. A
+    // controller with no motors, or a device with fewer than it declares,
+    // yields an index the driver rejects, which is the same as today.
+    unsigned int motorIndex = 0;
+    if (GetMotorIndex(feature, motorIndex))
+    {
+      primitive = CDriverPrimitive(PRIMITIVE_TYPE::MOTOR, motorIndex);
+      retVal = true;
+    }
+  }
 
   return retVal;
+}
+
+bool CAddonButtonMap::GetMotorIndex(const FeatureName& feature, unsigned int& motorIndex) const
+{
+  const KODI::GAME::ControllerPtr controller = m_manager.GetControllerProfiles().GetController(m_strControllerId);
+  if (!controller)
+    return false;
+
+  unsigned int index = 0;
+  for (const auto& physicalFeature : controller->Features())
+  {
+    if (physicalFeature.Type() != KODI::JOYSTICK::FEATURE_TYPE::MOTOR)
+      continue;
+
+    if (physicalFeature.Name() == feature)
+    {
+      motorIndex = index;
+      return true;
+    }
+
+    ++index;
+  }
+
+  return false;
 }
 
 void CAddonButtonMap::AddScalar(const FeatureName& feature, const CDriverPrimitive& primitive)

--- a/xbmc/peripherals/addons/AddonButtonMap.h
+++ b/xbmc/peripherals/addons/AddonButtonMap.h
@@ -59,6 +59,20 @@ public:
   void AddScalar(const KODI::JOYSTICK::FeatureName& feature,
                  const KODI::JOYSTICK::CDriverPrimitive& primitive) override;
 
+private:
+  /*!
+   * \brief Position of a motor among the motors this controller declares
+   *
+   * Motors are never mapped by the configuration wizard, because a motor is
+   * not something the user can activate on request. Position is what the
+   * drivers order them by, so it is what they are matched on here.
+   *
+   * \return True if the controller declares this feature as a motor
+   */
+  bool GetMotorIndex(const KODI::JOYSTICK::FeatureName& feature, unsigned int& motorIndex) const;
+
+public:
+
   bool GetAnalogStick(const KODI::JOYSTICK::FeatureName& feature,
                       KODI::JOYSTICK::ANALOG_STICK_DIRECTION direction,
                       KODI::JOYSTICK::CDriverPrimitive& primitive) override;


### PR DESCRIPTION
Rumble does not work for any game client, with any controller. There are two reasons, and this fixes both.

## 1. The request never reaches the peripheral

`CGameClientJoystick::SetRumble` reads `InputReceiver()`, which is always null there. The receiver belongs to `CPortInput` — that is what calls `RegisterInputHandler`, so that is what `CAddonInputHandling` attaches its `CDriverReceiving` to. `CGameClientJoystick` sits behind it and is never given one. Ask the port instead.

## 2. Nothing ever maps a motor

With the above fixed, the request reaches the peripheral and is refused, because the button map has no entry for the feature.

Every other feature is mapped by the configuration wizard, which asks the user to activate each one in turn. A motor cannot be activated on request, so the wizard never offers one — and no button map has ever contained a motor entry. Not the shipped ones (I checked all 43 Linux button maps; none has a motor), and not user-generated ones, because there is no path in the UI to create one.

So `CDriverReceiving::SetRumbleState` looks the feature up, finds nothing, and drops it.

Position is the only thing available to map a motor by, and it is what the drivers already order them by: the first motor a controller declares is the strong one, the second the weak one, matching the order evdev reports them. When the button map has no entry and the controller profile calls the feature a motor, this maps it to that position.

A controller declaring no motors is unaffected. A device with fewer motors than the controller declares yields an index its driver rejects, which is what happens today.

## How it was found

Flycast on LibreELEC with an 8BitDo Pro 2, then N64 and PlayStation cores. The core requests the rumble interface and gets it, `game.libretro` maps the motor to a controller feature, the button map resolves it (`game.controller.n64 feature "motor" -> libretro index 1`), and nothing happens.

The commits also add a one-off log line for the first motor event accepted and the first refused, naming which failure it was. That is what located both causes, and it seemed worth keeping — a rumble request that goes nowhere is otherwise completely silent. It was the change in that message from "no input receiver is attached" to "the peripheral would not take it" that showed the first fix had worked and revealed the second.

## A Linux caveat worth knowing

On Linux this also needs the peripheral.joystick driver set to **udev** rather than the joystick API: `CJoystickLinux` has no `SetMotorState` at all, while `CJoystickUdev` has force feedback. That is a user setting in the add-on, not something this PR changes.

## Testing

Both causes verified from logs before and after. I have not yet felt a controller buzz on hardware with the full chain in place — flagging that plainly rather than claiming a pass I have not run. Will confirm and follow up here.
