### PR TITLE
RetroAchievements - Implement Encore Mode (Ability to reearn earned achievements)

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -19539,7 +19539,17 @@ msgctxt "#35299"
 msgid "Still looking this game up on RetroAchievements..."
 msgstr ""
 
-#empty strings from id 35300 to 35504
+#. Label of the setting that enables RetroAchievements encore mode
+msgctxt "#35300"
+msgid "Encore mode"
+msgstr ""
+
+#. Help text for the encore mode setting
+msgctxt "#35301"
+msgid "Play for achievements you have already earned. They are re-activated so they can be earned again, and nothing is submitted for them a second time."
+msgstr ""
+
+#empty strings from id 35302 to 35504
 
 #. connection state "host unreachable"
 #: xbmc/pvr/addons/PVRClients.cpp

--- a/system/settings/settings.xml
+++ b/system/settings/settings.xml
@@ -2845,6 +2845,11 @@
           <default>false</default>
           <control type="toggle" />
         </setting>
+        <setting id="gamesachievements.encore" type="boolean" label="35300" help="35301">
+          <level>0</level>
+          <default>false</default>
+          <control type="toggle" />
+        </setting>
       </group>
     </category>
   </section>

--- a/xbmc/addons/kodi-dev-kit/include/kodi/addon-instance/Game.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/addon-instance/Game.h
@@ -984,6 +984,23 @@ public:
   }
   //----------------------------------------------------------------------------
 
+  //============================================================================
+  /// @brief Turn encore mode on or off
+  ///
+  /// Encore mode re-activates achievements the player has already earned, so
+  /// they can be played for again. Nothing is submitted for them a second time.
+  ///
+  /// The achievement runtime is recreated for each game, so this is sent on
+  /// every load rather than only when the setting changes.
+  ///
+  /// @param[in] enabled True to enable encore mode
+  /// @return The add-on error, or @ref GAME_ERROR_NO_ERROR
+  ///
+  /// @note Added in Game API 8.1.0
+  ///
+  virtual GAME_ERROR RCSetEncoreModeEnabled(bool enabled) { return GAME_ERROR_NOT_IMPLEMENTED; }
+  //----------------------------------------------------------------------------
+
   ///@}
 
   //--==----==----==----==----==----==----==----==----==----==----==----==----==--
@@ -1407,6 +1424,7 @@ private:
     instance->game->toAddon->AchievementStateSize = ADDON_AchievementStateSize;
     instance->game->toAddon->SerializeAchievements = ADDON_SerializeAchievements;
     instance->game->toAddon->DeserializeAchievements = ADDON_DeserializeAchievements;
+    instance->game->toAddon->RCSetEncoreModeEnabled = ADDON_RCSetEncoreModeEnabled;
 
     instance->game->toAddon->CheatReset = ADDON_CheatReset;
     instance->game->toAddon->GetMemory = ADDON_GetMemory;
@@ -1622,6 +1640,13 @@ private:
   {
     return static_cast<CInstanceGame*>(instance->toAddon->addonInstance)
         ->DeserializeAchievements(data, size);
+  }
+
+  inline static GAME_ERROR ADDON_RCSetEncoreModeEnabled(const AddonInstance_Game* instance,
+                                                        bool enabled)
+  {
+    return static_cast<CInstanceGame*>(instance->toAddon->addonInstance)
+        ->RCSetEncoreModeEnabled(enabled);
   }
 
   // --- Cheat operations --------------------------------------------------------

--- a/xbmc/addons/kodi-dev-kit/include/kodi/c-api/addon-instance/game.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/c-api/addon-instance/game.h
@@ -1503,6 +1503,7 @@ extern "C"
     GAME_ERROR(__cdecl* DeserializeAchievements)
     (const struct AddonInstance_Game*, const uint8_t*, size_t);
     void(__cdecl* FreeString)(const AddonInstance_Game*, char*);
+    GAME_ERROR(__cdecl* RCSetEncoreModeEnabled)(const AddonInstance_Game*, bool);
   } KodiToAddonFuncTable_Game;
 
   /*!

--- a/xbmc/addons/kodi-dev-kit/include/kodi/versions.h
+++ b/xbmc/addons/kodi-dev-kit/include/kodi/versions.h
@@ -97,7 +97,7 @@
 #define ADDON_INSTANCE_VERSION_AUDIOENCODER_DEPENDS   "c-api/addon-instance/audioencoder.h" \
                                                       "addon-instance/AudioEncoder.h"
 
-#define ADDON_INSTANCE_VERSION_GAME                   "8.0.0"
+#define ADDON_INSTANCE_VERSION_GAME                   "8.1.0"
 #define ADDON_INSTANCE_VERSION_GAME_MIN               "8.0.0"
 #define ADDON_INSTANCE_VERSION_GAME_XML_ID            "kodi.binary.instance.game"
 #define ADDON_INSTANCE_VERSION_GAME_DEPENDS           "c-api/addon-instance/game.h" \

--- a/xbmc/games/GameSettings.cpp
+++ b/xbmc/games/GameSettings.cpp
@@ -42,6 +42,7 @@ const std::string SETTING_GAMES_ACHIEVEMENTS_USERNAME = "gamesachievements.usern
 const std::string SETTING_GAMES_ACHIEVEMENTS_PASSWORD = "gamesachievements.password";
 const std::string SETTING_GAMES_ACHIEVEMENTS_TOKEN = "gamesachievements.token";
 const std::string SETTING_GAMES_ACHIEVEMENTS_LOGGED_IN = "gamesachievements.loggedin";
+const std::string SETTING_GAMES_ACHIEVEMENTS_ENCORE = "gamesachievements.encore";
 
 constexpr auto LOGIN_TO_RETRO_ACHIEVEMENTS_URL =
     "https://retroachievements.org/dorequest.php?r=login2";
@@ -281,6 +282,11 @@ bool CGameSettings::IsAccountVerified(const std::string& username, const std::st
 
   CLog::Log(LOGERROR, "CGameSettings::IsAccountVerified -- verification request failed");
   return false;
+}
+
+bool CGameSettings::GetAchievementsEncore() const
+{
+  return m_settings->GetBool(SETTING_GAMES_ACHIEVEMENTS_ENCORE);
 }
 
 bool CGameSettings::GetAchievementsLoggedIn() const

--- a/xbmc/games/GameSettings.h
+++ b/xbmc/games/GameSettings.h
@@ -43,6 +43,9 @@ public:
 
   bool GetAchievementsLoggedIn() const;
 
+  //! \brief Whether achievements already earned should be earnable again
+  bool GetAchievementsEncore() const;
+
   /*!
    * \brief Record whether the player is logged in to RetroAchievements
    *

--- a/xbmc/games/addons/GameClient.cpp
+++ b/xbmc/games/addons/GameClient.cpp
@@ -263,6 +263,7 @@ bool CGameClient::OpenFile(const CFileItem& file,
 
   // Before the game loads: the client signs in as part of identifying it
   Cheevos().SendCredentials();
+  Cheevos().SendEncoreMode();
 
   try
   {
@@ -310,6 +311,7 @@ bool CGameClient::OpenStandalone(RETRO::IStreamManager& streamManager, IGameInpu
   // achievements too, and sending nothing is how a session left over from a
   // player who has since signed out gets dropped
   Cheevos().SendCredentials();
+  Cheevos().SendEncoreMode();
 
   try
   {
@@ -720,6 +722,23 @@ bool CGameClient::SetRetroAchievementsCredentials(const std::string& username,
   catch (...)
   {
     LogException("SetRetroAchievementsCredentials()");
+  }
+
+  return false;
+}
+
+bool CGameClient::SetEncoreModeEnabled(bool enabled)
+{
+  std::unique_lock lock(m_critSection);
+
+  try
+  {
+    return LogError(m_ifc.game->toAddon->RCSetEncoreModeEnabled(m_ifc.game, enabled),
+                    "RCSetEncoreModeEnabled()");
+  }
+  catch (...)
+  {
+    LogException("RCSetEncoreModeEnabled()");
   }
 
   return false;

--- a/xbmc/games/addons/GameClient.h
+++ b/xbmc/games/addons/GameClient.h
@@ -230,6 +230,7 @@ public:
    * The account is held by Kodi, which owns the settings it is entered in.
    */
   bool SetRetroAchievementsCredentials(const std::string& username, const std::string& token);
+  bool SetEncoreModeEnabled(bool enabled);
 
   // Implementation of IHwFramebufferCallback
   void HardwareContextReset() override;

--- a/xbmc/games/addons/cheevos/GameClientCheevos.cpp
+++ b/xbmc/games/addons/cheevos/GameClientCheevos.cpp
@@ -317,6 +317,13 @@ void CGameClientCheevos::OnGameClosed()
   NotifyDialogs();
 }
 
+bool CGameClientCheevos::SendEncoreMode()
+{
+  const CGameSettings& gameSettings = CServiceBroker::GetGameServices().GameSettings();
+
+  return m_gameClient.SetEncoreModeEnabled(gameSettings.GetAchievementsEncore());
+}
+
 bool CGameClientCheevos::SendCredentials()
 {
   const CGameSettings& gameSettings = CServiceBroker::GetGameServices().GameSettings();

--- a/xbmc/games/addons/cheevos/GameClientCheevos.h
+++ b/xbmc/games/addons/cheevos/GameClientCheevos.h
@@ -72,6 +72,14 @@ public:
    */
   bool SendCredentials();
 
+  /*!
+   * \brief Tell the client whether to play for earned achievements again
+   *
+   * Sent on every load, because the achievement runtime is built per game and
+   * would otherwise keep whatever the last one was told.
+   */
+  bool SendEncoreMode();
+
 private:
   CGameClient& m_gameClient;
   AddonInstance_Game& m_struct;


### PR DESCRIPTION
Replaying a game you have finished is silent. Every achievement is unlocked, so
none of them are armed and none of them fire. Encore mode re-arms them, and a
second run through a favourite behaves like the first.

Nothing is submitted for them a second time. The server record stands, the point
total does not move, and an achievement earned again is reported exactly as one
earned for the first time.

### How it works

rc_client already implements this. It decides whether an achievement is active
by testing it against the player's unlock record, and encore mode is the flag
that makes that test always pass. What it lacked was any way to be told.

The decision has to be made before the game loads, because that is when the
achievements are armed, so this is sent alongside the credentials rather than
when the setting changes. The achievement runtime is rebuilt per game, so a
client told once would forget by the next load.

### Setting

A toggle under RetroAchievements, off by default. It is a replay aid rather
than a mode that changes what a session is worth, so nothing else in the UI is
conditioned on it.

### Game API

Goes to 8.1.0. This is the first call Kodi makes *into* the add-on for
achievements -- everything before it went the other way -- and it is appended to
`KodiToAddonFuncTable_Game`, so the minimum stays at 8.0.0 and add-ons built
against it keep loading. One that does not implement it returns
`GAME_ERROR_NOT_IMPLEMENTED` and plays as before.

### Add-on side

kodi-game/game.libretro#180.

### Tested

Balloon Fight (fceumm), account with 3 of its 25 achievements already earned.
Toggled live, without restarting Kodi, reloading the same game each time:

| setting | rcheevos reports | achievements armed |
|---|---|---|
| encore on | `Encore mode enabled` | **26/26** |
| encore off | `Encore mode disabled` | **22/26** |

The four that change are the 3 earned achievements plus a system notice that
was also already earned.
