### PR TITLE
Games: Let an add-on name its own platforms

### DIFF
--- a/xbmc/games/addons/GameClient.cpp
+++ b/xbmc/games/addons/GameClient.cpp
@@ -63,6 +63,7 @@ using namespace GAME;
 namespace
 {
 constexpr const char* GAME_PROPERTY_SUPPORTS_DISC_CONTROL = "supports_disc_control";
+constexpr const char* GAME_PROPERTY_PLATFORMS = "platforms";
 
 /*
  * \brief Convert to lower case and canonicalize with a leading "."
@@ -113,6 +114,11 @@ CGameClient::CGameClient(const ADDON::AddonInfoPtr& addonInfo)
                               .asBoolean();
 
   std::tie(m_emulatorName, m_platforms) = ParseLibretroName(Name());
+
+  const std::string platforms =
+      addonInfo->Type(AddonType::GAMEDLL)->GetValue(GAME_PROPERTY_PLATFORMS).asString();
+  if (!platforms.empty())
+    m_platforms = platforms;
 }
 
 CGameClient::~CGameClient(void)


### PR DESCRIPTION
The Kodi half of kodi-game/kodi-game-scripting#147, per https://github.com/kodi-game/kodi-game-scripting/issues/147#issuecomment-5543912339 — "use the add-on provided value to override the value parsed in Kodi".

`CGameClient` derives the platform it displays by splitting it back out of the add-on name, which works because libretro names its cores `Platforms (Emulator)`. Nothing else can say it, so an add-on that doesn't follow that convention — `ScummVM`, `VeMUlator`, `Oberon RISC Emulator`, or any non-libretro game add-on — has no way to describe itself correctly.

This reads the `<platforms>` tag the add-on already carries and prefers it, falling back to the name parse when it's empty. `ParseLibretroName()` is untouched.

Empty tags stay empty: `CAddonInfoBuilder::ParseXMLExtension` only records child elements that have text, so the 85-of-133 cores currently shipping `<platforms></platforms>` don't produce an empty override — they fall through to the name as before.

The generator side is kodi-game/kodi-game-scripting#148, which fills that tag in for the first time.